### PR TITLE
Effect v4 r1: migrate src/types/* schemas to array-form syntax

### DIFF
--- a/src/types/error.ts
+++ b/src/types/error.ts
@@ -20,11 +20,11 @@ const PushFailedBase = Schema.Struct({
   message: Schema.String,
 });
 
-export const PushFailedBody = Schema.Union(
+export const PushFailedBody = Schema.Union([
   Schema.Struct({
     ...PushFailedBase.fields,
     origin: Schema.Literal("server"),
-    reason: Schema.Literal("database", "parse", "oooMutation", "unsupportedPushVersion", "internal"),
+    reason: Schema.Literals(["database", "parse", "oooMutation", "unsupportedPushVersion", "internal"]),
   }),
   Schema.Struct({
     ...PushFailedBase.fields,
@@ -36,9 +36,9 @@ export const PushFailedBody = Schema.Union(
   Schema.Struct({
     ...PushFailedBase.fields,
     origin: Schema.Literal("zeroCache"),
-    reason: Schema.Literal("timeout", "parse", "internal"),
+    reason: Schema.Literals(["timeout", "parse", "internal"]),
   }),
-);
+]);
 
 const TransformFailedBase = Schema.Struct({
   kind: Schema.Literal("TransformFailed"),
@@ -50,11 +50,11 @@ const TransformFailedBase = Schema.Struct({
   message: Schema.String,
 });
 
-export const TransformFailedBody = Schema.Union(
+export const TransformFailedBody = Schema.Union([
   Schema.Struct({
     ...TransformFailedBase.fields,
     origin: Schema.Literal("server"),
-    reason: Schema.Literal("database", "parse", "internal"),
+    reason: Schema.Literals(["database", "parse", "internal"]),
   }),
   Schema.Struct({
     ...TransformFailedBase.fields,
@@ -66,6 +66,6 @@ export const TransformFailedBody = Schema.Union(
   Schema.Struct({
     ...TransformFailedBase.fields,
     origin: Schema.Literal("zeroCache"),
-    reason: Schema.Literal("timeout", "parse", "internal"),
+    reason: Schema.Literals(["timeout", "parse", "internal"]),
   }),
-);
+]);

--- a/src/types/push.ts
+++ b/src/types/push.ts
@@ -7,12 +7,12 @@ import { PushFailedBody } from "./error.js";
 
 const PrimaryKey = Schema.Array(Schema.String);
 
-const PrimaryKeyValue = Schema.Union(Schema.String, Schema.Number, Schema.Boolean);
+const PrimaryKeyValue = Schema.Union([Schema.String, Schema.Number, Schema.Boolean]);
 
-const PrimaryKeyValueRecord = Schema.Record({ key: Schema.String, value: PrimaryKeyValue });
+const PrimaryKeyValueRecord = Schema.Record(Schema.String, PrimaryKeyValue);
 
-const Value = Schema.Union(JsonSchema, Schema.Undefined);
-const Row = Schema.Record({ key: Schema.String, value: Value });
+const Value = Schema.Union([JsonSchema, Schema.Undefined]);
+const Row = Schema.Record(Schema.String, Value);
 
 const CRUD_MUTATION_NAME = "_zero_crud";
 
@@ -20,7 +20,7 @@ const CRUD_MUTATION_NAME = "_zero_crud";
 const CLEANUP_RESULTS_MUTATION_NAME = "_zero_cleanupResults";
 
 // biome-ignore lint/correctness/noUnusedVariables: borrowed code
-const CleanupResultsArg = Schema.Union(
+const CleanupResultsArg = Schema.Union([
   // Legacy format (no type field) - treat as single
   Schema.Struct({
     clientGroupID: Schema.String,
@@ -40,7 +40,7 @@ const CleanupResultsArg = Schema.Union(
     clientGroupID: Schema.String,
     clientIDs: Schema.NonEmptyArray(Schema.String),
   }),
-);
+]);
 
 /**
  * Inserts if entity with id does not already exist.
@@ -85,13 +85,13 @@ const DeleteOp = Schema.Struct({
   value: PrimaryKeyValueRecord,
 });
 
-const CrudOp = Schema.Union(InsertOp, UpsertOp, UpdateOp, DeleteOp);
+const CrudOp = Schema.Union([InsertOp, UpsertOp, UpdateOp, DeleteOp]);
 
 const CrudArg = Schema.Struct({
   ops: Schema.Array(CrudOp),
 });
 
-const CrudArgs = Schema.Tuple(CrudArg);
+const CrudArgs = Schema.Tuple([CrudArg]);
 
 const CrudMutation = Schema.Struct({
   type: Schema.Literal("crud"),
@@ -111,7 +111,7 @@ const CustomMutation = Schema.Struct({
   timestamp: Schema.Number,
 });
 
-export const Mutation = Schema.Union(CrudMutation, CustomMutation);
+export const Mutation = Schema.Union([CrudMutation, CustomMutation]);
 export type Mutation = typeof Mutation.Type;
 
 export const PushBody = Schema.Struct({
@@ -133,7 +133,7 @@ export const PushBody = Schema.Struct({
 export type PushBody = typeof PushBody.Type;
 
 // biome-ignore lint/correctness/noUnusedVariables: borrowed code
-const PushMessage = Schema.Tuple(Schema.Literal("push"), PushBody);
+const PushMessage = Schema.Tuple([Schema.Literal("push"), PushBody]);
 
 const MutationId = Schema.Struct({
   id: Schema.Number,
@@ -150,11 +150,11 @@ export const AppError = Schema.Struct({
 export type AppError = typeof AppError.Type;
 
 export const ZeroError = Schema.Struct({
-  error: Schema.Union(
+  error: Schema.Literals([
     /** @deprecated push oooMutation errors are now represented as ['error', { ... }] messages */
-    Schema.Literal("oooMutation"),
-    Schema.Literal("alreadyProcessed"),
-  ),
+    "oooMutation",
+    "alreadyProcessed",
+  ]),
   details: Schema.optional(JsonSchema),
 });
 
@@ -165,13 +165,13 @@ const MutationOk = Schema.Struct({
   data: Schema.optional(JsonSchema),
 });
 
-const MutationError = Schema.Union(AppError, ZeroError);
+const MutationError = Schema.Union([AppError, ZeroError]);
 
-export const MutationResult = Schema.Union(
+export const MutationResult = Schema.Union([
   // We flip the original order here as otherwise values of type MutationError would get parsed as MutationOk with empty `data`
   MutationError,
   MutationOk,
-);
+]);
 export type MutationResult = typeof MutationResult.Type;
 
 export const MutationResponse = Schema.Struct({
@@ -233,18 +233,18 @@ const ZeroPusherError = Schema.Struct({
 /**
  * @deprecated push errors are now represented as ['error', { ... }] messages
  */
-const PushError = Schema.Union(UnsupportedPushVersion, UnsupportedSchemaVersion, HttpError, ZeroPusherError);
+const PushError = Schema.Union([UnsupportedPushVersion, UnsupportedSchemaVersion, HttpError, ZeroPusherError]);
 
-const PushResponseBody = Schema.Union(PushOk, PushError);
+const PushResponseBody = Schema.Union([PushOk, PushError]);
 
-export const PushResponse = Schema.Union(PushResponseBody, PushFailedBody);
+export const PushResponse = Schema.Union([PushResponseBody, PushFailedBody]);
 export type PushResponse = typeof PushResponse.Type;
 
 // biome-ignore lint/correctness/noUnusedVariables: borrowed code
-const PushResponseMessage = Schema.Tuple(Schema.Literal("pushResponse"), PushResponseBody);
+const PushResponseMessage = Schema.Tuple([Schema.Literal("pushResponse"), PushResponseBody]);
 
 // biome-ignore lint/correctness/noUnusedVariables: borrowed code
-const AckMutationResponsesMessage = Schema.Tuple(Schema.Literal("ackMutationResponses"), MutationId);
+const AckMutationResponsesMessage = Schema.Tuple([Schema.Literal("ackMutationResponses"), MutationId]);
 
 /**
  * The schema for the querystring parameters of the custom push endpoint.

--- a/src/types/queries.ts
+++ b/src/types/queries.ts
@@ -39,18 +39,18 @@ const ParseErroredQuery = Schema.Struct({
   details: Schema.optional(JsonSchema),
 });
 
-const ErroredQuery = Schema.Union(AppErroredQuery, ParseErroredQuery);
+const ErroredQuery = Schema.Union([AppErroredQuery, ParseErroredQuery]);
 
-const TransformResponseBody = Schema.Array(Schema.Union(TransformedQuery, ErroredQuery));
+const TransformResponseBody = Schema.Array(Schema.Union([TransformedQuery, ErroredQuery]));
 
-export const TransformRequestMessage = Schema.Tuple(Schema.Literal("transform"), TransformRequestBody);
+export const TransformRequestMessage = Schema.Tuple([Schema.Literal("transform"), TransformRequestBody]);
 export type TransformRequestMessage = typeof TransformRequestMessage.Type;
 
 // biome-ignore lint/correctness/noUnusedVariables: borrowed code
-const TransformErrorMessage = Schema.Tuple(Schema.Literal("transformError"), Schema.Array(ErroredQuery));
+const TransformErrorMessage = Schema.Tuple([Schema.Literal("transformError"), Schema.Array(ErroredQuery)]);
 
-const TransformFailedMessage = Schema.Tuple(Schema.Literal("transformFailed"), TransformFailedBody);
+const TransformFailedMessage = Schema.Tuple([Schema.Literal("transformFailed"), TransformFailedBody]);
 
-const TransformOkMessage = Schema.Tuple(Schema.Literal("transformed"), TransformResponseBody);
+const TransformOkMessage = Schema.Tuple([Schema.Literal("transformed"), TransformResponseBody]);
 
-export const TransformResponseMessage = Schema.Union(TransformOkMessage, TransformFailedMessage);
+export const TransformResponseMessage = Schema.Union([TransformOkMessage, TransformFailedMessage]);


### PR DESCRIPTION
## Summary

Round 1 PR — pure 1:1 mechanical migration of \`src/types/*\` schemas to Effect v4's array-form Schema syntax. **Branches off #38 (base PR), not main.**

## Changes

In v4, \`Schema.Union\` / \`Schema.Tuple\` take an array of schemas, multi-value \`Schema.Literal(...)\` is renamed to \`Schema.Literals([...])\`, and \`Schema.Record\` is positional. All renames; no semantics or shape changes.

- \`Schema.Union(a, b, c)\` → \`Schema.Union([a, b, c])\`
- \`Schema.Tuple(a, b)\` → \`Schema.Tuple([a, b])\`
- \`Schema.Literal(\"a\", \"b\", ...)\` → \`Schema.Literals([\"a\", \"b\", ...])\`
- \`Schema.Record({ key, value })\` → \`Schema.Record(key, value)\`

\`types/push.ts\` also collapses the \`ZeroError.error\` union of two single-string literals into a single \`Schema.Literals\`.

## Files

- \`src/types/error.ts\`
- \`src/types/push.ts\`
- \`src/types/queries.ts\`

## Test plan

- [ ] Diff against #38 review confirms only mechanical Schema renames
- [ ] Will be verified end-to-end once all round 1/round 2 PRs merge and typecheck/tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)