### PR TITLE
Effect v4 r1: result/mutators/server.test 1:1 renames

### DIFF
--- a/src/internal/server.test.ts
+++ b/src/internal/server.test.ts
@@ -15,7 +15,8 @@ describe("ServerSynchronizationContext", () => {
       );
       Exit.match(result, {
         onSuccess: () => expect.fail("Expected failure"),
-        onFailure: (cause) => expect(cause).toStrictEqual(Cause.fail(new NoTransactionError())),
+        onFailure: (cause) =>
+          expect(Cause.findErrorOption(cause)).toEqual(Cause.findErrorOption(Cause.fail(new NoTransactionError()))),
       });
     }),
   );

--- a/src/internal/server.test.ts
+++ b/src/internal/server.test.ts
@@ -1,4 +1,5 @@
 import { describe, it } from "@effect/vitest";
+import { assertExitFailure } from "@effect/vitest/utils";
 import * as Cause from "effect/Cause";
 import * as Effect from "effect/Effect";
 import * as Exit from "effect/Exit";
@@ -7,17 +8,13 @@ import { NoTransactionError, ServerSynchronizationContext } from "./server.js";
 describe("ServerSynchronizationContext", () => {
   it.effect(
     "finalize should return NoTransactionError when called without guard",
-    Effect.fn(function* ({ expect }) {
+    Effect.fn(function* () {
       const result = yield* Effect.void.pipe(
         ServerSynchronizationContext.finalize,
         Effect.provide(ServerSynchronizationContext.Default),
         Effect.exit,
       );
-      Exit.match(result, {
-        onSuccess: () => expect.fail("Expected failure"),
-        onFailure: (cause) =>
-          expect(Cause.findErrorOption(cause)).toEqual(Cause.findErrorOption(Cause.fail(new NoTransactionError()))),
-      });
+      assertExitFailure(result, Cause.fail(new NoTransactionError()));
     }),
   );
 

--- a/src/mutators.ts
+++ b/src/mutators.ts
@@ -15,7 +15,7 @@ export type AnyMutatorFns<R = any> = {
 };
 
 // biome-ignore lint/suspicious/noExplicitAny: upper bound to allow everything
-export type AnyMutatorSchema = Schema.Schema<any, any, never>;
+export type AnyMutatorSchema = Schema.Codec<any, any>;
 export type AnyMutatorSchemas = Record<string, AnyMutatorSchema | Record<string, AnyMutatorSchema>>;
 
 export type MutatorFns<TSchema extends AnyMutatorSchemas> = {
@@ -70,9 +70,13 @@ export function make(schema: AnyMutatorSchemas, mutators: AnyMutatorFns): AnyMut
 
   return Rec.map(mutators, (v, name) => {
     return Match.value([v, schema[name]]).pipe(
-      Match.when([Predicate.isFunction, Schema.isSchema], ([mutator, schema]) => makeMutator(schema, mutator)),
-      Match.when([Predicate.isRecord, Predicate.isRecord], ([mutator, schema]) =>
-        Rec.map(mutator, (mutator, name) => makeMutator(Option.getOrThrow(Rec.get(schema, name)), mutator)),
+      Match.when([Predicate.isFunction, Schema.isSchema], ([mutator, schema]) =>
+        makeMutator(schema as AnyMutatorSchema, mutator as AnyMutatorFn),
+      ),
+      Match.when([Predicate.isObject, Predicate.isObject], ([mutator, schema]) =>
+        Rec.map(mutator as Record<string, AnyMutatorFn>, (mutator, name) =>
+          makeMutator(Option.getOrThrow(Rec.get(schema as Record<string, AnyMutatorSchema>, name)), mutator),
+        ),
       ),
       Match.orElseAbsurd,
     );

--- a/src/mutators.ts
+++ b/src/mutators.ts
@@ -70,13 +70,9 @@ export function make(schema: AnyMutatorSchemas, mutators: AnyMutatorFns): AnyMut
 
   return Rec.map(mutators, (v, name) => {
     return Match.value([v, schema[name]]).pipe(
-      Match.when([Predicate.isFunction, Schema.isSchema], ([mutator, schema]) =>
-        makeMutator(schema as AnyMutatorSchema, mutator as AnyMutatorFn),
-      ),
+      Match.when([Predicate.isFunction, Schema.isSchema], ([mutator, schema]) => makeMutator(schema, mutator)),
       Match.when([Predicate.isObject, Predicate.isObject], ([mutator, schema]) =>
-        Rec.map(mutator as Record<string, AnyMutatorFn>, (mutator, name) =>
-          makeMutator(Option.getOrThrow(Rec.get(schema as Record<string, AnyMutatorSchema>, name)), mutator),
-        ),
+        Rec.map(mutator, (mutator, name) => makeMutator(Option.getOrThrow(Rec.get(schema, name)), mutator)),
       ),
       Match.orElseAbsurd,
     );

--- a/src/result.ts
+++ b/src/result.ts
@@ -77,11 +77,11 @@ export class QueryError extends Data.TaggedError("QueryError")<{
 
 export const make = <A, E>(value: AsyncResult.AsyncResult<QueryResult<A>, E>): Result<A, E> =>
   Match.valueTags(value, {
-    Initial: (): Result<A, E> => AsyncResult.initial(),
-    Success: ({ value }): Result<A, E> =>
+    Initial: () => AsyncResult.initial(),
+    Success: ({ value }) =>
       Match.valueTags(value, {
-        Partial: (value): Result<A, E> => AsyncResult.success(value),
-        Complete: (value): Result<A, E> => AsyncResult.success(value),
+        Partial: (value) => AsyncResult.success(value),
+        Complete: (value) => AsyncResult.success(value),
         Error: (e): Result<A, E> => AsyncResult.failure(Cause.fail(new QueryError(e))),
       }),
     Failure: (e): Result<A, E> => AsyncResult.failure(e.cause),

--- a/src/result.ts
+++ b/src/result.ts
@@ -6,7 +6,7 @@ import * as Match from "effect/Match";
 import * as Option from "effect/Option";
 import * as Predicate from "effect/Predicate";
 import * as Struct from "effect/Struct";
-import { AsyncResult as AtomResult } from "effect/unstable/reactivity";
+import { AsyncResult } from "effect/unstable/reactivity";
 import type { QueryResult } from "./internal/query-result.js";
 
 /*
@@ -48,47 +48,44 @@ This has a few key benefits:
   partial results, resulting a further simplified type of `Initial | Success(A) | Failure(E | QueryError)`.
 */
 
-export type Result<A, E = never> = AtomResult.AsyncResult<
+export type Result<A, E = never> = AsyncResult.AsyncResult<
   QueryResult.Partial<A> | QueryResult.Complete<A>,
   E | QueryError
 >;
 export namespace Result {
-  export type Initial<A, E = never> = AtomResult.Initial<
+  export type Initial<A, E = never> = AsyncResult.Initial<
     QueryResult.Partial<A> | QueryResult.Complete<A>,
     E | QueryError
   >;
-  export type Failure<A, E = never> = AtomResult.Failure<
+  export type Failure<A, E = never> = AsyncResult.Failure<
     QueryResult.Partial<A> | QueryResult.Complete<A>,
     E | QueryError
   >;
-  export type Success<A, E = never> = AtomResult.Success<
+  export type Success<A, E = never> = AsyncResult.Success<
     QueryResult.Partial<A> | QueryResult.Complete<A>,
     E | QueryError
   >;
 
   // More granular Partial and Complete types
-  export type Partial<A, E = never> = AtomResult.Success<QueryResult.Partial<A>, E | QueryError>;
-  export type Complete<A, E = never> = AtomResult.Success<QueryResult.Complete<A>, E | QueryError>;
+  export type Partial<A, E = never> = AsyncResult.Success<QueryResult.Partial<A>, E | QueryError>;
+  export type Complete<A, E = never> = AsyncResult.Success<QueryResult.Complete<A>, E | QueryError>;
 }
 
 export class QueryError extends Data.TaggedError("QueryError")<{
   readonly details: QueryResult.Error["details"];
 }> {}
 
-export const make = <A, E>(value: AtomResult.AsyncResult<QueryResult<A>, E>): Result<A, E> => {
-  type Inner = QueryResult.Partial<A> | QueryResult.Complete<A>;
-  type Err = E | QueryError;
-  return Match.valueTags(value, {
-    Initial: (): Result<A, E> => AtomResult.initial<Inner, Err>(),
+export const make = <A, E>(value: AsyncResult.AsyncResult<QueryResult<A>, E>): Result<A, E> =>
+  Match.valueTags(value, {
+    Initial: (): Result<A, E> => AsyncResult.initial(),
     Success: ({ value }): Result<A, E> =>
       Match.valueTags(value, {
-        Partial: (v): Result<A, E> => AtomResult.success<Inner, Err>(v),
-        Complete: (v): Result<A, E> => AtomResult.success<Inner, Err>(v),
-        Error: (e): Result<A, E> => AtomResult.failure<Inner, Err>(Cause.fail(new QueryError(e))),
+        Partial: (value): Result<A, E> => AsyncResult.success(value),
+        Complete: (value): Result<A, E> => AsyncResult.success(value),
+        Error: (e): Result<A, E> => AsyncResult.failure(Cause.fail(new QueryError(e))),
       }),
-    Failure: (e): Result<A, E> => AtomResult.failure<Inner, Err>(e.cause),
+    Failure: (e): Result<A, E> => AsyncResult.failure(e.cause),
   });
-};
 
 // based on: https://github.com/tim-smart/effect-atom/blob/04c15cacda42dd230782f52c0e978400793a502c/packages/atom/src/Result.ts#L424
 export const match: {
@@ -130,34 +127,34 @@ export const match: {
 );
 
 export const mapSuccess: {
-  <A, B>(f: (value: A) => B): <E = never>(self: AtomResult.Success<A, E>) => AtomResult.Success<B, E>;
-  <A, B, E = never>(self: AtomResult.Success<A, E>, f: (value: A) => B): AtomResult.Success<B, E>;
-} = Fn.dual(2, <A, B, E = never>(self: AtomResult.Success<A, E>, f: (value: A) => B) => AtomResult.map(self, f));
+  <A, B>(f: (value: A) => B): <E = never>(self: AsyncResult.Success<A, E>) => AsyncResult.Success<B, E>;
+  <A, B, E = never>(self: AsyncResult.Success<A, E>, f: (value: A) => B): AsyncResult.Success<B, E>;
+} = Fn.dual(2, <A, B, E = never>(self: AsyncResult.Success<A, E>, f: (value: A) => B) => AsyncResult.map(self, f));
 
 export const acceptPartialWith: {
   <A, E = never>(
     self: Result<A, E>,
     predicate: (value: HumanReadable<A>) => boolean,
   ):
-    | AtomResult.Initial<HumanReadable<A>, E>
-    | AtomResult.Success<HumanReadable<A>, QueryError | E>
-    | AtomResult.Failure<HumanReadable<A>, QueryError | E>;
+    | AsyncResult.Initial<HumanReadable<A>, E>
+    | AsyncResult.Success<HumanReadable<A>, QueryError | E>
+    | AsyncResult.Failure<HumanReadable<A>, QueryError | E>;
   <A, E = never>(
     self: Result<A, E>,
   ): (
     predicate: (value: HumanReadable<A>) => boolean,
   ) =>
-    | AtomResult.Initial<HumanReadable<A>, E>
-    | AtomResult.Success<HumanReadable<A>, QueryError | E>
-    | AtomResult.Failure<HumanReadable<A>, QueryError | E>;
+    | AsyncResult.Initial<HumanReadable<A>, E>
+    | AsyncResult.Success<HumanReadable<A>, QueryError | E>
+    | AsyncResult.Failure<HumanReadable<A>, QueryError | E>;
 } = Fn.dual(2, <A, E = never>(self: Result<A, E>, predicate: (value: HumanReadable<A>) => boolean) =>
-  AtomResult.match(self, {
+  AsyncResult.match(self, {
     onSuccess: (success) =>
       Predicate.isTagged(success.value, "Partial") && !predicate(success.value.value)
-        ? AtomResult.initial<HumanReadable<A>, E>(success.waiting)
+        ? AsyncResult.initial(success.waiting)
         : mapSuccess(success, Struct.get("value")),
     onFailure: (failure) =>
-      AtomResult.failure<HumanReadable<A>, E | QueryError>(failure.cause, {
+      AsyncResult.failure(failure.cause, {
         waiting: failure.waiting,
         previousSuccess: failure.previousSuccess.pipe(
           Option.flatMap((success) =>
@@ -167,7 +164,7 @@ export const acceptPartialWith: {
           ),
         ),
       }),
-    onInitial: (initial) => AtomResult.initial<HumanReadable<A>, E>(initial.waiting),
+    onInitial: (initial) => AsyncResult.initial(initial.waiting),
   }),
 );
 
@@ -188,9 +185,9 @@ export const acceptPartialMode: {
      **/
     mode: AcceptPartialMode,
   ):
-    | AtomResult.Initial<HumanReadable<A>, E>
-    | AtomResult.Success<HumanReadable<A>, QueryError | E>
-    | AtomResult.Failure<HumanReadable<A>, QueryError | E>;
+    | AsyncResult.Initial<HumanReadable<A>, E>
+    | AsyncResult.Success<HumanReadable<A>, QueryError | E>
+    | AsyncResult.Failure<HumanReadable<A>, QueryError | E>;
   <A, E>(
     /**
      * - `acceptCached` -> Will resolve to the partial result if it is available
@@ -206,9 +203,9 @@ export const acceptPartialMode: {
   ): (
     self: Result<A, E>,
   ) =>
-    | AtomResult.Initial<HumanReadable<A>, E>
-    | AtomResult.Success<HumanReadable<A>, QueryError | E>
-    | AtomResult.Failure<HumanReadable<A>, QueryError | E>;
+    | AsyncResult.Initial<HumanReadable<A>, E>
+    | AsyncResult.Success<HumanReadable<A>, QueryError | E>
+    | AsyncResult.Failure<HumanReadable<A>, QueryError | E>;
 } = Fn.dual(2, <A, E>(self: Result<A, E>, mode: AcceptPartialMode) =>
   Match.value(mode).pipe(
     Match.when("waitForServer", () => acceptPartialWith(self, () => false)),

--- a/src/result.ts
+++ b/src/result.ts
@@ -1,4 +1,3 @@
-import { Result as AtomResult } from "@effect-atom/atom";
 import type { HumanReadable } from "@rocicorp/zero";
 import * as Cause from "effect/Cause";
 import * as Data from "effect/Data";
@@ -7,14 +6,15 @@ import * as Match from "effect/Match";
 import * as Option from "effect/Option";
 import * as Predicate from "effect/Predicate";
 import * as Struct from "effect/Struct";
+import { AsyncResult as AtomResult } from "effect/unstable/reactivity";
 import type { QueryResult } from "./internal/query-result.js";
 
 /*
 ### Introduction
 
-When using effect-atom with effect-zero, you will often have atoms which contain a type in the form of
+When using `effect/unstable/reactivity` (atoms) with effect-zero, you will often have atoms which contain a type in the form of
 
-`@effect-atom/atom`.Result<`@rocicorp/zero/react`.QueryResult<A>, E>
+`AsyncResult<QueryResult<A>, E>`
 
 However, such a type is not easy to work with.
 The purpose of `effect-zero`.Result is to provide a more convenient type for this use case.
@@ -22,8 +22,8 @@ The purpose of `effect-zero`.Result is to provide a more convenient type for thi
 ### Background
 
 To start, let's analyze the possible states of the original type:
-- The outer `@effect-atom/atom`.Result may be `Initial<_, _>`, `Failure<_, E>`, or `Success<QueryResult, _>`.
-- The inner `@rocicorp/zero/react`.QueryResult may be `unknown<A>`, `complete<A>`, or `error`.
+- The outer `AsyncResult` may be `Initial<_, _>`, `Failure<_, E>`, or `Success<QueryResult, _>`.
+- The inner `QueryResult` may be `unknown<A>`, `complete<A>`, or `error`.
 
 This means that there are 5 total possible states:
 - Initial, representing the state before the query has been executed on either the client or the server.
@@ -43,12 +43,15 @@ On the other hand, `effect-zero`.Result has the following states:
 
 This has a few key benefits:
 - It allows you to deal with errors in a more streamlined way, as now all error states are represented as a `Failure(E | QueryError)`,
-  thus you can use the builtin facilities of `effect-atom`.Result to work with the possible error states.
+  thus you can use the builtin facilities of `AsyncResult` to work with the possible error states.
 - We provide a method `acceptPartialMode` which allows for simplifying the type further by specifying the situations in which you want to accept
   partial results, resulting a further simplified type of `Initial | Success(A) | Failure(E | QueryError)`.
 */
 
-export type Result<A, E = never> = AtomResult.Result<QueryResult.Partial<A> | QueryResult.Complete<A>, E | QueryError>;
+export type Result<A, E = never> = AtomResult.AsyncResult<
+  QueryResult.Partial<A> | QueryResult.Complete<A>,
+  E | QueryError
+>;
 export namespace Result {
   export type Initial<A, E = never> = AtomResult.Initial<
     QueryResult.Partial<A> | QueryResult.Complete<A>,
@@ -72,17 +75,20 @@ export class QueryError extends Data.TaggedError("QueryError")<{
   readonly details: QueryResult.Error["details"];
 }> {}
 
-export const make = <A, E>(value: AtomResult.Result<QueryResult<A>, E>): Result<A, E> =>
-  Match.valueTags(value, {
-    Initial: () => AtomResult.initial(),
-    Success: ({ value }) =>
+export const make = <A, E>(value: AtomResult.AsyncResult<QueryResult<A>, E>): Result<A, E> => {
+  type Inner = QueryResult.Partial<A> | QueryResult.Complete<A>;
+  type Err = E | QueryError;
+  return Match.valueTags(value, {
+    Initial: (): Result<A, E> => AtomResult.initial<Inner, Err>(),
+    Success: ({ value }): Result<A, E> =>
       Match.valueTags(value, {
-        Partial: (value) => AtomResult.success(value),
-        Complete: (value) => AtomResult.success(value),
-        Error: (e) => AtomResult.failure(Cause.fail(new QueryError(e))),
+        Partial: (v): Result<A, E> => AtomResult.success<Inner, Err>(v),
+        Complete: (v): Result<A, E> => AtomResult.success<Inner, Err>(v),
+        Error: (e): Result<A, E> => AtomResult.failure<Inner, Err>(Cause.fail(new QueryError(e))),
       }),
-    Failure: (e) => AtomResult.failure(e.cause),
+    Failure: (e): Result<A, E> => AtomResult.failure<Inner, Err>(e.cause),
   });
+};
 
 // based on: https://github.com/tim-smart/effect-atom/blob/04c15cacda42dd230782f52c0e978400793a502c/packages/atom/src/Result.ts#L424
 export const match: {
@@ -151,7 +157,7 @@ export const acceptPartialWith: {
         ? AtomResult.initial<HumanReadable<A>, E>(success.waiting)
         : mapSuccess(success, Struct.get("value")),
     onFailure: (failure) =>
-      AtomResult.failure<E | QueryError, HumanReadable<A>>(failure.cause, {
+      AtomResult.failure<HumanReadable<A>, E | QueryError>(failure.cause, {
         waiting: failure.waiting,
         previousSuccess: failure.previousSuccess.pipe(
           Option.flatMap((success) =>


### PR DESCRIPTION
## Summary

Round 1 PR — pure 1:1 mechanical renames across three files. **Branches off #38 (base PR), not main.**

## Changes

### \`src/result.ts\`
- Drop \`@effect-atom/atom\` import; replace with \`effect/unstable/reactivity\` (the in-tree v4 home of Atom/Result).
- \`AtomResult.Result\` → \`AtomResult.AsyncResult\` everywhere.
- Add explicit type annotations to \`Match.valueTags\` branches and to \`AtomResult.initial / success / failure\` calls, since v4's stricter inference loses them otherwise.
- Comment text updated to reference the new package.

### \`src/mutators.ts\`
- \`Schema.Schema<any, any, never>\` → \`Schema.Codec<any, any>\` (v4 type rename).
- \`Predicate.isRecord\` (removed in v4) → \`Predicate.isObject\`, with corresponding \`as\` casts on the broader inferred type.

### \`src/internal/server.test.ts\`
- \`expect(cause).toStrictEqual(Cause.fail(new NoTransactionError()))\` → compare \`Cause.findErrorOption(cause)\` against \`Cause.findErrorOption(Cause.fail(...))\`. Cause's internal layout changed in v4 so structural equality on the whole Cause no longer holds; comparing the extracted error keeps the assertion's intent.

## Test plan

- [ ] Diff against #38 review confirms only mechanical renames
- [ ] End-to-end verification once all round 1/round 2 PRs merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)