### PR TITLE
Effect v4 r1b: Runtime/ParseResult removal + Effect.context/run*ExitWith

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -4,10 +4,8 @@ import * as Data from "effect/Data";
 import * as Effect from "effect/Effect";
 import * as Exit from "effect/Exit";
 import * as Match from "effect/Match";
-import type * as ParseResult from "effect/ParseResult";
 import * as Predicate from "effect/Predicate";
 import * as Rec from "effect/Record";
-import * as Runtime from "effect/Runtime";
 import * as Schema from "effect/Schema";
 import type * as ClientTransaction from "./client-transaction.js";
 import * as Mutators from "./mutators.js";
@@ -22,8 +20,8 @@ export const make = Effect.fn(function* <TSchema extends ZeroSchema, TMutators e
   mutators: TMutators,
   options: Omit<ZeroOptions<TSchema, UnwrapMutators<TSchema, TMutators>>, "schema" | "mutators">,
 ) {
-  const runtime =
-    yield* Effect.runtime<
+  const ctx =
+    yield* Effect.context<
       Exclude<Mutators.ExtractMutatorsRequirements<TMutators>, ClientTransaction.ClientTransaction>
     >();
 
@@ -33,7 +31,7 @@ export const make = Effect.fn(function* <TSchema extends ZeroSchema, TMutators e
         Effect.catchTag("ParseError", (e) => new ClientArgsParseError({ cause: Cause.fail(e) })),
         Effect.flatMap(mutator),
         Effect.provideService(transaction, tx),
-        Runtime.runPromiseExit(runtime),
+        Effect.runPromiseExitWith(ctx),
       );
       return Exit.getOrElse(exit, (c) => {
         // Extract underlying error bypassing FiberFailure
@@ -62,7 +60,7 @@ type UnwrapMutator<TSchema extends ZeroSchema, TMutators extends Mutators.AnyMut
   ? (transaction: ZeroTransaction<TSchema>) => Promise<void>
   : (
       transaction: ZeroTransaction<TSchema>,
-      args: Schema.Schema.Encoded<TMutators[typeof Mutators.MutatorSchemaSymbol]>,
+      args: Schema.Codec.Encoded<TMutators[typeof Mutators.MutatorSchemaSymbol]>,
     ) => Promise<void>;
 
 type UnwrapMutators<TSchema extends ZeroSchema, TMutators extends Mutators.AnyMutators> = {
@@ -76,5 +74,5 @@ type UnwrapMutators<TSchema extends ZeroSchema, TMutators extends Mutators.AnyMu
 } & {};
 
 export class ClientArgsParseError extends Data.TaggedError("ClientArgsParseError")<{
-  readonly cause: Cause.Cause<ParseResult.ParseError>;
+  readonly cause: Cause.Cause<Schema.SchemaError>;
 }> {}

--- a/src/server-transaction.ts
+++ b/src/server-transaction.ts
@@ -12,7 +12,6 @@ import * as Effect from "effect/Effect";
 import * as Exit from "effect/Exit";
 import * as Layer from "effect/Layer";
 import * as Predicate from "effect/Predicate";
-import * as Runtime from "effect/Runtime";
 import type * as ClientTransaction from "./client-transaction.js";
 import {
   MutationAlreadyProcessedError,
@@ -52,7 +51,7 @@ export const make = <const Id extends string, TSchema extends ZeroSchema, TTrans
     );
 
   const execute = Effect.fn(function* <A, E, R>(effect: Effect.Effect<A, E, R>) {
-    const runtime = yield* Effect.runtime<
+    const ctx = yield* Effect.context<
       ServerTransactionInput | Exclude<R, ClientTransaction.ClientTransaction | ServerTransactionContext>
     >();
     const result = yield* Deferred.make<A, E | Effect.Effect.Error<typeof checkAndIncrementLastMutationId>>();
@@ -66,7 +65,7 @@ export const make = <const Id extends string, TSchema extends ZeroSchema, TTrans
               Layer.succeed(ServerTransactionContext, { transaction, transactionHooks }),
               Layer.succeed(clientTransaction, transaction),
             ]),
-            (effect) => Runtime.runPromiseExit(runtime, effect, { signal }),
+            (effect) => Effect.runPromiseExitWith(ctx)(effect, { signal }),
           );
           Deferred.unsafeDone(result, exit);
           return Exit.getOrElse(exit, () => {

--- a/src/server.ts
+++ b/src/server.ts
@@ -196,7 +196,7 @@ export const handleQuery = Effect.fn(function* <E, R1, R2>(
           Arr.findFirst(queries, (q) => q[QueryNameSymbol] === name).pipe(
             Effect.catchTag("NoSuchElementException", () => new QueryNotFound({ name })),
             Effect.flatMap((query) => query[RunQuerySymbol]({ _tag: "Encoded", args })),
-            (effect) => Effect.runSyncExitWith(ctx)(effect),
+            Effect.runSyncExitWith(ctx),
             Exit.getOrElse((cause) => {
               throw new QueryUserError<E>({ cause });
             }),

--- a/src/server.ts
+++ b/src/server.ts
@@ -9,10 +9,8 @@ import * as Exit from "effect/Exit";
 import * as Fn from "effect/Function";
 import * as Match from "effect/Match";
 import * as Option from "effect/Option";
-import type * as ParseResult from "effect/ParseResult";
 import * as Predicate from "effect/Predicate";
 import * as Rec from "effect/Record";
-import * as Runtime from "effect/Runtime";
 import * as Schema from "effect/Schema";
 import * as Stream from "effect/Stream";
 import * as Str from "effect/String";
@@ -167,7 +165,7 @@ class MutatorNotFoundError extends Data.TaggedError("MutatorNotFoundError")<{
 }> {}
 
 class ServerArgsParseError extends Data.TaggedError("ServerArgsParseError")<{
-  readonly cause: Cause.Cause<ParseResult.ParseError>;
+  readonly cause: Cause.Cause<Schema.SchemaError>;
 }> {}
 
 const MutationUserErrorTypeId = Symbol.for(prefixId("MutationUserError"));
@@ -190,7 +188,7 @@ export const handleQuery = Effect.fn(function* <E, R1, R2>(
   schema: ZeroSchema,
   payload: TransformRequestMessage,
 ) {
-  const runtime = yield* Effect.runtime<R1 | R2>();
+  const ctx = yield* Effect.context<R1 | R2>();
   return yield* Effect.tryPromise({
     try: () =>
       handleQueryRequest(
@@ -198,7 +196,7 @@ export const handleQuery = Effect.fn(function* <E, R1, R2>(
           Arr.findFirst(queries, (q) => q[QueryNameSymbol] === name).pipe(
             Effect.catchTag("NoSuchElementException", () => new QueryNotFound({ name })),
             Effect.flatMap((query) => query[RunQuerySymbol]({ _tag: "Encoded", args })),
-            (effect) => Runtime.runSyncExit(runtime, effect),
+            (effect) => Effect.runSyncExitWith(ctx)(effect),
             Exit.getOrElse((cause) => {
               throw new QueryUserError<E>({ cause });
             }),
@@ -222,7 +220,7 @@ class QueryNotFound extends Data.TaggedError("QueryNotFound")<{ name: string }> 
 
 const QueryUserErrorTypeId = Symbol.for(prefixId("QueryUserError"));
 class QueryUserError<E> extends Data.TaggedError("QueryUserError")<{
-  cause: Cause.Cause<E | ParseResult.ParseError | QueryNotFound>;
+  cause: Cause.Cause<E | Schema.SchemaError | QueryNotFound>;
 }> {
   readonly [QueryUserErrorTypeId] = QueryUserErrorTypeId;
   static is<E>(e: unknown): e is QueryUserError<E> {


### PR DESCRIPTION
## Summary

Round 1 sub-file PR — pure 1:1 relocations of removed v3 modules. **Branches off #38 (base PR).**

## Changes

Across `src/client.ts`, `src/server.ts`, `src/server-transaction.ts`:

- Drop `import * as Runtime from "effect/Runtime"` (module removed in v4)
- Drop `import type * as ParseResult from "effect/ParseResult"` (module removed in v4)
- `Effect.runtime<R>()` → `Effect.context<R>()`. Return type changes from `Runtime<R>` to `Context<R>`; downstream `Runtime.run*` calls take `Context` now too, so the change is end-to-end.
- `Runtime.runPromiseExit(rt)` → `Effect.runPromiseExitWith(ctx)` (pipe form / curried form with `{ signal }`)
- `Runtime.runSyncExit(rt, eff)` → `Effect.runSyncExitWith(ctx)(eff)`
- `Cause.Cause<ParseResult.ParseError>` → `Cause.Cause<Schema.SchemaError>`
- `Schema.Schema.Encoded<S>` → `Schema.Codec.Encoded<S>` (v4 split Schema.Schema into Type-only and Codec-namespace helpers; Type is unchanged)

## Verified against upstream sources

Subagent compared v3 (`effect@3.19.3`) and v4 (`effect-smol@4.0.0-beta.64`) source for each of the renames above. All are exact 1:1 with no behavior change beyond `Effect.runtime` → `Effect.context`'s return type swap (Context replaces Runtime everywhere it's threaded through).

## Test plan

- [ ] Reviews confirm no semantic shift, only renames/relocations
- [ ] Full typecheck once remaining round-1 sub-file PRs land

🤖 Generated with [Claude Code](https://claude.com/claude-code)
