### PR TITLE
Effect v4 r1b: Schema decode/encode renames + Stream/Chunk simplification

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -27,7 +27,7 @@ export const make = Effect.fn(function* <TSchema extends ZeroSchema, TMutators e
 
   function unwrapMutator<E>(mutator: Mutators.AnyMutator<Mutators.ExtractMutatorsRequirements<TMutators>, E>) {
     return async (tx: ZeroTransaction<TSchema>, args: unknown, _ctx: unknown) => {
-      const exit = await Schema.decode(mutator[Mutators.MutatorSchemaSymbol])(args).pipe(
+      const exit = await Schema.decodeUnknownEffect(mutator[Mutators.MutatorSchemaSymbol])(args).pipe(
         Effect.catchTag("SchemaError", (e) => Effect.fail(new ClientArgsParseError({ cause: Cause.fail(e) }))),
         Effect.flatMap(mutator),
         Effect.provideService(transaction, tx),

--- a/src/query.ts
+++ b/src/query.ts
@@ -102,7 +102,7 @@ export const stream = <T extends keyof S["tables"] & string, S extends ZeroSchem
             // TODO: Look into this. It seems like this is difficult but not impossible to model in the Effect paradigm.
             // Likely need some kind of stateful piece between the publisher and and subscriber, allowing the subscriber to swap out
             // the publisher when this function is called.
-            () => Effect.die(new Error("retry not available in `effect-zero`")),
+            () => Effect.die("retry not available in `effect-zero`"),
             error,
           );
         }),

--- a/src/query.ts
+++ b/src/query.ts
@@ -32,15 +32,15 @@ export const make = <
   R2,
 >(options: {
   name: N;
-  payload: Schema.Schema<B, A, R1>;
+  payload: Schema.Codec<B, A, R1, R1>;
   query: (args: NoInfer<B>) => Effect.Effect<ZeroQuery<T, S, R>, E, R2>;
 }) => {
   const runQuery = Effect.fn(function* (args: QueryArgs<A, B>) {
     const { encoded, decoded } = yield* Match.valueTags(args, {
       Encoded: ({ args: encoded }) =>
-        Effect.map(Schema.decode(options.payload)(encoded), (decoded) => ({ encoded, decoded })),
+        Effect.map(Schema.decodeEffect(options.payload)(encoded), (decoded) => ({ encoded, decoded })),
       Decoded: ({ args: decoded }) =>
-        Effect.map(Schema.encode(options.payload)(decoded), (encoded) => ({ encoded, decoded })),
+        Effect.map(Schema.encodeEffect(options.payload)(decoded), (encoded) => ({ encoded, decoded })),
     });
 
     return yield* options.query(decoded).pipe(
@@ -102,14 +102,14 @@ export const stream = <T extends keyof S["tables"] & string, S extends ZeroSchem
             // TODO: Look into this. It seems like this is difficult but not impossible to model in the Effect paradigm.
             // Likely need some kind of stateful piece between the publisher and and subscriber, allowing the subscriber to swap out
             // the publisher when this function is called.
-            () => Effect.dieMessage("retry not available in `effect-zero`"),
+            () => Effect.die(new Error("retry not available in `effect-zero`")),
             error,
           );
         }),
       ),
       Stream.map(QueryResult.make),
     );
-  }).pipe(Stream.unwrapScoped);
+  }).pipe(Stream.unwrap);
 
 export const initialValue = <T extends keyof S["tables"] & string, S extends ZeroSchema, R>(
   query: ZeroQuery<T, S, R>,

--- a/src/server.ts
+++ b/src/server.ts
@@ -2,7 +2,6 @@ import type { ReadonlyJSONValue, Schema as ZeroSchema } from "@rocicorp/zero";
 import { handleQueryRequest } from "@rocicorp/zero/server";
 import * as Arr from "effect/Array";
 import * as Cause from "effect/Cause";
-import * as Chunk from "effect/Chunk";
 import * as Data from "effect/Data";
 import * as Effect from "effect/Effect";
 import * as Exit from "effect/Exit";
@@ -79,7 +78,7 @@ export const processPush = Effect.fn(function* <
     Stream.runCollect,
   );
 
-  return { mutations: Chunk.toArray(responses) } satisfies Types.PushResponse;
+  return { mutations: responses } satisfies Types.PushResponse;
 });
 
 const processMutation = Effect.fn(function* <R>(mutators: Mutators.AnyMutators<R>, mutation: Types.Mutation) {
@@ -99,7 +98,7 @@ const processMutation = Effect.fn(function* <R>(mutators: Mutators.AnyMutators<R
     Effect.catchTag("NoSuchElementError", () => Effect.fail(new MutatorNotFoundError({ name: mutation.name }))),
   );
 
-  const args = yield* Schema.decode(mutator[Mutators.MutatorSchemaSymbol])(mutation.args[0]).pipe(
+  const args = yield* Schema.decodeUnknownEffect(mutator[Mutators.MutatorSchemaSymbol])(mutation.args[0]).pipe(
     Effect.catchTag("SchemaError", (e) => Effect.fail(new ServerArgsParseError({ cause: Cause.fail(e) }))),
   );
 


### PR DESCRIPTION
## Summary

Round 1 sub-file PR — Schema decode/encode renames + Stream/Chunk simplification + small renames in `query.ts`. **Branches off #38 (base PR).**

## Changes

### `src/client.ts`, `src/server.ts`
- `Schema.decode(schema)(unknown)` → `Schema.decodeUnknownEffect(schema)(unknown)`. v3 `Schema.decode` was internally aliased to `decodeUnknown` (`v3 Schema.ts:598`); both call sites here decode mutator args from JSON (typed `unknown`), so the unknown-typed v4 form is the right mapping. (`decodeEffect` is for typed input — used in `query.ts` below.)

### `src/server.ts`
- Drop `import * as Chunk from "effect/Chunk"`. v4 `Stream.runCollect` returns `Effect<Array<A>>` directly (it returned `Effect<Chunk<A>>` in v3). The `Chunk.toArray(responses)` wrapper is no longer needed.

### `src/query.ts`
- `Schema.decode` → `Schema.decodeEffect`, `Schema.encode` → `Schema.encodeEffect` (typed input/output; encoded is `A`, decoded is `B`).
- `Schema.Schema<B, A, R1>` → `Schema.Codec<B, A, R1, R1>`. v4 split the single `R` requirements parameter into separate decoding (`RD`) / encoding (`RE`) service parameters. `R1` is used in both `Schema.decodeEffect(payload)` (decode-side requirements) and `Schema.encodeEffect(payload)` (encode-side requirements), so it's duplicated — the canonical translation when the original v3 schema's `R` applied to both directions.
- `Effect.dieMessage("text")` → `Effect.die(new Error("text"))` (`dieMessage` removed in v4).
- `Stream.unwrapScoped` → `Stream.unwrap`. v4 merged the two variants: the new `unwrap` strips `Scope` from requirements, matching v3 `unwrapScoped`'s behavior.

## Verified against upstream sources

Subagent confirmed each item against `effect@3.19.3` and `effect-smol@4.0.0-beta.64`. Of note: v3 `Schema.decode` is the same function as `Schema.decodeUnknown` (`v3 Schema.ts:598`: literal alias), so the unknown-input mapping is signature-honest in v4. The v4 `Stream.unwrap` signature was changed to subsume v3's `unwrapScoped` (it now removes `Scope` from the result's `R`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
