### PR TITLE
Effect v4 r1b: misc renames (Cause/Effect/Predicate/Deferred/Ref + types.test)

### DIFF
--- a/src/internal/server.ts
+++ b/src/internal/server.ts
@@ -45,7 +45,7 @@ export class ServerSynchronizationContext extends Effect.Service<ServerSynchroni
         // If the transaction was executed successfully, swallow the error and just log it, otherwise re-throw it
         Effect.catchAllCause(
           Effect.fn(function* (e) {
-            if (yield* wasTransactionExecuted) {
+            if (yield* SynchronizedRef.get(wasTransactionExecuted)) {
               return yield* Effect.logError("Error occurred after transaction execution completed", e);
             }
             return yield* Effect.failCause(e);
@@ -55,7 +55,7 @@ export class ServerSynchronizationContext extends Effect.Service<ServerSynchroni
         // Check that the transaction was executed during the mutation
         Effect.tap(
           Effect.gen(function* () {
-            if (!(yield* wasTransactionExecuted)) {
+            if (!(yield* SynchronizedRef.get(wasTransactionExecuted))) {
               return yield* new NoTransactionError();
             }
           }),

--- a/src/server-transaction.ts
+++ b/src/server-transaction.ts
@@ -55,20 +55,20 @@ export const make = <const Id extends string, TSchema extends ZeroSchema, TTrans
     const runtime = yield* Effect.runtime<
       ServerTransactionInput | Exclude<R, ClientTransaction.ClientTransaction | ServerTransactionContext>
     >();
-    const result = yield* Deferred.make<A, E | Effect.Effect.Error<typeof checkAndIncrementLastMutationId>>();
+    const result = yield* Deferred.make<A, E | Effect.Error<typeof checkAndIncrementLastMutationId>>();
 
     const transactionInput = yield* ServerTransactionInput;
     yield* Effect.tryPromise({
       try: (signal) =>
         database.transaction(async (transaction, transactionHooks) => {
-          const exit = await Effect.zipRight(checkAndIncrementLastMutationId, effect).pipe(
+          const exit = await Effect.flatMap(checkAndIncrementLastMutationId, () => effect).pipe(
             Effect.provide([
               Layer.succeed(ServerTransactionContext, { transaction, transactionHooks }),
               Layer.succeed(clientTransaction, transaction),
             ]),
             (effect) => Runtime.runPromiseExit(runtime, effect, { signal }),
           );
-          Deferred.unsafeDone(result, exit);
+          Deferred.doneUnsafe(result, exit);
           return Exit.getOrElse(exit, () => {
             // This error's purpose is to differentiate between "external" errors
             // that originate from the user-defined mutator code and "internal" errors
@@ -90,7 +90,7 @@ export const make = <const Id extends string, TSchema extends ZeroSchema, TTrans
       },
     }).pipe(Effect.catchTag("ServerTransactionUserError", () => Effect.void));
 
-    return yield* result;
+    return yield* Deferred.await(result);
   }, ServerSynchronizationContext.guard);
 
   const checkAndIncrementLastMutationId = Effect.gen(function* () {

--- a/src/server.ts
+++ b/src/server.ts
@@ -93,7 +93,7 @@ const processMutation = Effect.fn(function* <R>(mutators: Mutators.AnyMutators<R
     Rec.get<string>(namespace),
     Option.flatMap((mutator) =>
       Match.value([mutator, name]).pipe(
-        Match.when([Predicate.isRecord, Predicate.isString], ([mutator, name]) => Rec.get<string>(name)(mutator)),
+        Match.when([Predicate.isObject, Predicate.isString], ([mutator, name]) => Rec.get<string>(name)(mutator)),
         Match.when([Predicate.isFunction, Predicate.isUndefined], ([mutator]) => Option.some(mutator)),
         Match.orElse(() => Option.none()),
       ),
@@ -208,7 +208,7 @@ export const handleQuery = Effect.fn(function* <E, R1, R2>(
       ),
     catch: (e) =>
       Option.liftPredicate(e, QueryUserError.is<E>).pipe(
-        Option.flatMap((e) => Cause.failureOption(e.cause)),
+        Option.flatMap((e) => Cause.findErrorOption(e.cause)),
         Option.getOrElse(() => new QueryRequestError({ cause: Cause.fail(e) })),
       ),
   });

--- a/src/types.test.ts
+++ b/src/types.test.ts
@@ -163,7 +163,7 @@ describe("Type tests", () => {
       const serverEffect = Server.processPush(serverTransaction, mutators, {} as any, {} as any);
 
       // Server effect should require both NestedDummyTag and NestedDummyTag2
-      expectTypeOf<Effect.Effect.Context<typeof serverEffect>>().toEqualTypeOf<NestedDummyTag | NestedDummyTag2>();
+      expectTypeOf<Effect.Services<typeof serverEffect>>().toEqualTypeOf<NestedDummyTag | NestedDummyTag2>();
     });
 
     it("mutator requirements should propagate", () => {
@@ -195,7 +195,7 @@ describe("Type tests", () => {
       const serverEffect = Server.processPush(serverTransaction, mutators, {} as any, {} as any);
 
       // Server effect should require both DummyTag and DummyTag2
-      expectTypeOf<Effect.Effect.Context<typeof serverEffect>>().toEqualTypeOf<DummyTag | DummyTag2>();
+      expectTypeOf<Effect.Services<typeof serverEffect>>().toEqualTypeOf<DummyTag | DummyTag2>();
     });
 
     it("processPush has no extra requirements when mutators have none", () => {
@@ -212,7 +212,7 @@ describe("Type tests", () => {
 
       const effect = Server.processPush(serverTransaction, mutators, {} as any, {} as any);
 
-      expectTypeOf<Effect.Effect.Context<typeof effect>>().toEqualTypeOf<never>();
+      expectTypeOf<Effect.Services<typeof effect>>().toEqualTypeOf<never>();
     });
   });
 


### PR DESCRIPTION
## Summary

Round 1 sub-file PR — leftover 1:1 renames spanning four files. Each item is a single locally-equivalent swap. **Branches off #38 (base PR).**

## Changes

### `src/server.ts`
- `Predicate.isRecord` → `Predicate.isObject`. Verified byte-identical runtime body (`typeof === "object" && !== null && !Array.isArray(x)`) — `isRecord` was removed in v4. Caller is `Match.when([..., Predicate.isString], ...)` where the matched value is necessarily a record built via object-literal syntax, so the equivalence is total in this context.
- `Cause.failureOption` → `Cause.findErrorOption` (rename only).

### `src/server-transaction.ts`
- `Effect.zipRight(a, b)` → `Effect.flatMap(a, () => b)`. `zipRight` was removed in v4; flatMap with a discarding arrow is the documented equivalent.
- `Effect.Effect.Error<X>` → `Effect.Error<X>`. v4 promoted the requirements-extraction helpers from namespace members to top-level type aliases.
- `Deferred.unsafeDone` → `Deferred.doneUnsafe` (rename). v4 also changes the return type from `void` to `boolean`; the only caller here ignores the return value, so no downstream impact.
- `yield* result` (Deferred) → `yield* Deferred.await(result)`. v4 `Deferred<A, E>` no longer extends `Effect.Effect<A, E>` (it now only implements `Variance` + `Pipeable`), so explicit `Deferred.await` is required.

### `src/internal/server.ts`
- `yield* wasTransactionExecuted` (SynchronizedRef) → `yield* SynchronizedRef.get(wasTransactionExecuted)` (two sites). v4 `Ref`/`SynchronizedRef` no longer extend `Effect`, so reads have to go through `.get`.

### `src/types.test.ts`
- `Effect.Effect.Context<X>` → `Effect.Services<X>` (three sites).

## Verified against upstream sources

Subagent confirmed each item against `effect@3.19.3` and `effect-smol@4.0.0-beta.64`. Notable empirical confirmations: `Predicate.isRecord` and `Predicate.isObject` produce identical results across `{}`, `[]`, `Date`, `Map`, class instances, functions, and `null`. v4 `Deferred` extends only `Variance, Pipeable` (not `Effect`); v4 `Ref` similarly. v4 `Stream.runCollect` returns `Effect<Array<A>>` (not addressed here but adjacent — handled in #43).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
