### PR TITLE
Effect v4 r1b: types.test.ts Schema.Tuple array-form

### DIFF
--- a/src/types.test.ts
+++ b/src/types.test.ts
@@ -305,13 +305,13 @@ describe("Type tests", () => {
     it("MakeQueryResult should be satisfied by query results", () => {
       const query1 = Query.make({
         name: "q1",
-        payload: Schema.Tuple(Schema.String),
+        payload: Schema.Tuple([Schema.String]),
         query: () => Effect.succeed(makeMockQuery()),
       });
 
       const query2 = Query.make({
         name: "q2",
-        payload: Schema.Tuple(),
+        payload: Schema.Tuple([]),
         query: () => Effect.succeed(makeMockQuery()),
       });
 


### PR DESCRIPTION
## Summary

Round 1 sub-file PR — apply the same mechanical rename done for `src/types/*` in #39 to `src/types.test.ts`. **Branches off #38 (base PR).**

## Changes

- `Schema.Tuple(a)` → `Schema.Tuple([a])`
- `Schema.Tuple()` → `Schema.Tuple([])`

(No Union calls exist in this file.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)