### PR TITLE
Effect v4 r2: types.test.ts Service fixtures + DateFromNumber

### DIFF
--- a/src/types.test.ts
+++ b/src/types.test.ts
@@ -1,12 +1,21 @@
 import { describe, expectTypeOf, it } from "@effect/vitest";
 import { queryInternalsTag } from "@rocicorp/zero/bindings";
+import * as Context from "effect/Context";
 import * as Effect from "effect/Effect";
 import * as Schema from "effect/Schema";
+import * as SchemaGetter from "effect/SchemaGetter";
 import * as ClientTransaction from "./client-transaction.js";
 import * as Mutators from "./mutators.js";
 import * as Query from "./query.js";
 import * as Server from "./server.js";
 import * as ServerTransaction from "./server-transaction.js";
+
+const DateFromNumber = Schema.Number.pipe(
+  Schema.decodeTo(Schema.Date, {
+    decode: SchemaGetter.transform((n: number) => new Date(n)),
+    encode: SchemaGetter.transform((d: Date) => d.getTime()),
+  }),
+);
 
 // Mock Zero schema for type tests
 const mockZeroSchema = {
@@ -125,13 +134,9 @@ describe("Type tests", () => {
     });
 
     it("nested mutator requirements should propagate", () => {
-      class NestedDummyTag extends Effect.Service<NestedDummyTag>()("effect-zero/test/NestedDummyTag", {
-        succeed: {},
-      }) {}
+      class NestedDummyTag extends Context.Service<NestedDummyTag, {}>()("effect-zero/test/NestedDummyTag") {}
 
-      class NestedDummyTag2 extends Effect.Service<NestedDummyTag2>()("effect-zero/test/NestedDummyTag2", {
-        succeed: {},
-      }) {}
+      class NestedDummyTag2 extends Context.Service<NestedDummyTag2, {}>()("effect-zero/test/NestedDummyTag2") {}
 
       const clientTransaction = ClientTransaction.make("TestClientTransactionNestedReq", mockZeroSchema);
       const serverTransaction = ServerTransaction.make(
@@ -167,13 +172,9 @@ describe("Type tests", () => {
     });
 
     it("mutator requirements should propagate", () => {
-      class DummyTag extends Effect.Service<DummyTag>()("effect-zero/test/DummyTag", {
-        succeed: {},
-      }) {}
+      class DummyTag extends Context.Service<DummyTag, {}>()("effect-zero/test/DummyTag") {}
 
-      class DummyTag2 extends Effect.Service<DummyTag2>()("effect-zero/test/DummyTag2", {
-        succeed: {},
-      }) {}
+      class DummyTag2 extends Context.Service<DummyTag2, {}>()("effect-zero/test/DummyTag2") {}
 
       const clientTransaction = ClientTransaction.make("TestClientTransaction2", mockZeroSchema);
       const serverTransaction = ServerTransaction.make("TestServerTransaction", mockDatabase, clientTransaction);
@@ -230,7 +231,7 @@ describe("Type tests", () => {
     it("query should accept and passthrough encoded non-JSON args", () => {
       const transformArgsQuery = Query.make({
         name: "transformArgs",
-        payload: Schema.DateFromNumber,
+        payload: DateFromNumber,
         query: Effect.fn(function* (a) {
           // Inside the query, 'a' should be the decoded type (Date)
           expectTypeOf<typeof a>().toEqualTypeOf<Date>();


### PR DESCRIPTION
## Summary

Round 2 — two file-local v4 migrations in `src/types.test.ts`. **Branches off #38 (base PR).**

## Changes

### 1. `Effect.Service` → `Context.Service` for test fixtures

`Effect.Service<X>()(name, { succeed: {} })` → `Context.Service<X, {}>()(name)` for the four `it()`-block-local fixture classes. v4 removed `Effect.Service`. The tests only use these as opaque service tags via `yield* T`, which `Context.Service` supports because the Service class extends `Yieldable`.

**v3 ↔ v4 reference:**
- v3 `Effect.Service` macro: `effect@3.19.3/packages/effect/src/Effect.ts` (the `Effect.Service<Self>()(name, { succeed | effect | scoped })` overload — removed in v4)
- v4 canonical replacement: `effect-smol/packages/effect/src/Context.ts:130-194` (`Context.Service<Self, T>()(name, options?)`)
- v4 typetest fixture using the same shape we adopt: `effect-smol/packages/effect/typetest/unstable/rpc/RpcMiddleware.tst.ts:5` — `class CurrentUser extends Context.Service<CurrentUser, { id: string }>()("CurrentUser") {}`

### 2. `Schema.DateFromNumber` → local `DateFromNumber`

v4 deliberately did not port `Schema.DateFromNumber`. Instead it ships `Schema.Date` and `Schema.DateFromString`, expecting users to spell out other transformations.

**v3 ↔ v4 reference:**
- v3 source definition: `effect@3.19.3/packages/effect/src/Schema.ts:6858-6866` —
  ```ts
  export class DateFromNumber extends transform(
    Number$.annotations({ description: "..." }), DateFromSelf,
    { strict: true, decode: (i) => new Date(i), encode: (a) => a.getTime() }
  ).annotations({ identifier: "DateFromNumber" }) {}
  ```
- v3 use sites in effect's own source/tests: only `effect@3.19.3/packages/effect/test/Schema/Schema/Date/DateFromNumber.test.ts` (its own test). No internal callers — i.e., users had to define their own equivalents in the field too.
- v4 idiom for the same Date↔Number transformation is open-coded inline using `Schema.decodeTo` + `SchemaTransformation.transform` / `SchemaGetter.transform`. The maintainers' own example in v4 source (Date↔Number, just inverted direction): `effect-smol/packages/effect/test/schema/toCodec.test.ts:22-28`:
  ```ts
  const FiniteFromDate = Schema.Date.pipe(Schema.decodeTo(
    Schema.Number,
    SchemaTransformation.transform({
      decode: (date) => date.getTime(),
      encode: (n) => new Date(n),
    }),
  ))
  ```
  This PR uses the equivalent shape with `SchemaGetter.transform` (the lower-level form documented at `effect-smol/packages/effect/src/SchemaGetter.ts:65-77`).

## Why isolated

Both fixtures are file-local. No exported types change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
