### PR TITLE
Effect v4 r2: query.ts Subscribable interface + Stream.callback

### DIFF
--- a/src/query.ts
+++ b/src/query.ts
@@ -88,10 +88,8 @@ export const stream = <T extends keyof S["tables"] & string, S extends ZeroSchem
       (view) => Effect.sync(() => view.destroy()),
     );
 
-    type ListenerArgs = Parameters<Parameters<(typeof view)["addListener"]>[0]>;
-
-    return Stream.callback<ListenerArgs>((queue) =>
-      Effect.sync(() => view.addListener((...args) => Queue.offerUnsafe(queue, args as ListenerArgs))),
+    return Stream.callback<Parameters<Parameters<(typeof view)["addListener"]>[0]>>((queue) =>
+      Effect.sync(() => view.addListener((...args) => Queue.offerUnsafe(queue, args))),
     ).pipe(
       Stream.mapEffect(([data, resultType, error]) =>
         Effect.sync(() => {

--- a/src/query.ts
+++ b/src/query.ts
@@ -4,12 +4,21 @@ import * as Effect from "effect/Effect";
 import * as Equal from "effect/Equal";
 import * as Hash from "effect/Hash";
 import * as Match from "effect/Match";
+import * as Queue from "effect/Queue";
 import * as Schema from "effect/Schema";
 import * as Stream from "effect/Stream";
-import * as Subscribable from "effect/Subscribable";
 import * as QueryResult from "./internal/query-result.js";
 import { prefixId } from "./internal/utils.js";
 import { deepClone, getDefaultSnapshot, getSnapshot } from "./snapshot.js";
+
+/**
+ * Local replacement for `effect/Subscribable` (removed in Effect v4).
+ * Models a current value with a stream of changes.
+ */
+export interface Subscribable<A> {
+  readonly get: Effect.Effect<A>;
+  readonly changes: Stream.Stream<A>;
+}
 
 // biome-ignore lint/suspicious/noConfusingVoidType: necessary to allow Schema.Void
 type QueryArgs<A extends ReadonlyJSONValue | void, B> = { _tag: "Encoded"; args: A } | { _tag: "Decoded"; args: B };
@@ -88,8 +97,10 @@ export const stream = <T extends keyof S["tables"] & string, S extends ZeroSchem
       (view) => Effect.sync(() => view.destroy()),
     );
 
-    return Stream.asyncEffect<Parameters<Parameters<(typeof view)["addListener"]>[0]>>((emit) =>
-      Effect.sync(() => view.addListener((...args) => emit.single(args))),
+    type ListenerArgs = Parameters<Parameters<(typeof view)["addListener"]>[0]>;
+
+    return Stream.callback<ListenerArgs>((queue) =>
+      Effect.sync(() => view.addListener((...args) => Queue.offerUnsafe(queue, args as ListenerArgs))),
     ).pipe(
       Stream.mapEffect(([data, resultType, error]) =>
         Effect.sync(() => {
@@ -118,11 +129,9 @@ export const initialValue = <T extends keyof S["tables"] & string, S extends Zer
 export const subscribable = <T extends keyof S["tables"] & string, S extends ZeroSchema, R>(
   zero: Zero<S>,
   query: ZeroQuery<T, S, R>,
-) => {
-  return Subscribable.make({
-    get: Effect.promise(() => zero.run(query, { type: "unknown" })).pipe(
-      Effect.map((value) => ({ _tag: "Partial", value }) satisfies QueryResult.QueryResult.Partial<R>),
-    ),
-    changes: stream(zero, query),
-  });
-};
+): Subscribable<QueryResult.QueryResult<R>> => ({
+  get: Effect.promise(() => zero.run(query, { type: "unknown" })).pipe(
+    Effect.map((value) => ({ _tag: "Partial", value }) satisfies QueryResult.QueryResult.Partial<R>),
+  ),
+  changes: stream(zero, query),
+});

--- a/src/query.ts
+++ b/src/query.ts
@@ -11,15 +11,6 @@ import * as QueryResult from "./internal/query-result.js";
 import { prefixId } from "./internal/utils.js";
 import { deepClone, getDefaultSnapshot, getSnapshot } from "./snapshot.js";
 
-/**
- * Local replacement for `effect/Subscribable` (removed in Effect v4).
- * Models a current value with a stream of changes.
- */
-export interface Subscribable<A> {
-  readonly get: Effect.Effect<A>;
-  readonly changes: Stream.Stream<A>;
-}
-
 // biome-ignore lint/suspicious/noConfusingVoidType: necessary to allow Schema.Void
 type QueryArgs<A extends ReadonlyJSONValue | void, B> = { _tag: "Encoded"; args: A } | { _tag: "Decoded"; args: B };
 
@@ -125,13 +116,3 @@ export const stream = <T extends keyof S["tables"] & string, S extends ZeroSchem
 export const initialValue = <T extends keyof S["tables"] & string, S extends ZeroSchema, R>(
   query: ZeroQuery<T, S, R>,
 ) => QueryResult.make<R>(getDefaultSnapshot(asQueryInternals(query).format.singular));
-
-export const subscribable = <T extends keyof S["tables"] & string, S extends ZeroSchema, R>(
-  zero: Zero<S>,
-  query: ZeroQuery<T, S, R>,
-): Subscribable<QueryResult.QueryResult<R>> => ({
-  get: Effect.promise(() => zero.run(query, { type: "unknown" })).pipe(
-    Effect.map((value) => ({ _tag: "Partial", value }) satisfies QueryResult.QueryResult.Partial<R>),
-  ),
-  changes: stream(zero, query),
-});


### PR DESCRIPTION
## Summary

Round 2 — `src/query.ts` v4 migration, re-oriented to drop the v3-shaped `Subscribable` API entirely. **Branches off #38 (base PR).**

## Background

v3 effect-zero exposed `subscribable(zero, query): Subscribable<QueryResult<R>>` returning a `{ get: Effect<A>; changes: Stream<A> }` pair, intended to feed v3 `effect-atom`'s `Atom.subscribable` (`effect-atom/packages/atom/src/Atom.ts:911`).

In v4:
- `effect/Subscribable` was **removed entirely** (no module under `src/` or `unstable/`).
- `Atom.subscribable` was **also removed** from the in-tree atom (`effect/unstable/reactivity/Atom`).
- **No v4 Atom builder consumes a `{ get, changes }` pair.**

So the `Subscribable` shape no longer maps to anything v4 needs.

## Changes

### 1. Drop `effect/Subscribable` import; **don't** introduce a local replacement

Removed the `import * as Subscribable from "effect/Subscribable"` and removed the local `Subscribable<A>` interface. There's no v4 consumer for the shape, so keeping it would be dead surface.

### 2. Drop the `subscribable(zero, query)` function

Callers now compose the v4-canonical recipe directly:

```ts
Atom.make(stream(zero, query), { initialValue: initialValue(query) })
```

The two helpers needed (`stream` and `initialValue`) are already exported from `query.ts` — no new wrapper required.

**v3 → v4 reference:**
- v3 `effect-atom/packages/atom/src/Atom.ts:911-952` — `Atom.subscribable(sub: Subscribable<A>): Atom<...>` (removed in v4).
- v4 canonical replacement: `effect-smol/packages/effect/src/unstable/reactivity/Atom.ts:373` — the `Atom.make` Stream overload `(stream, options?: { initialValue?: A }) => Atom<AsyncResult<A, E | NoSuchElementError>>`. Test: `effect-smol/packages/effect/test/reactivity/Atom.test.ts:1056-1068`.

### 3. `Stream.asyncEffect((emit) => ...)` → `Stream.callback((queue) => ...)`

v4 explicitly documents `Stream.callback` as the replacement for `Stream.asyncEffect`. New shape uses `Queue.offerUnsafe(queue, ...)` instead of `emit.single(...)`.

**v3 → v4 reference:**
- v3 `Stream.asyncEffect`: `effect@3.19.3/packages/effect/src/Stream.ts` (signature) — removed in v4.
- v4 `Stream.callback`: `effect-smol/packages/effect/src/Stream.ts:719-771` (docstring explicitly: "This API replaces … `Stream.asyncEffect`"). Canonical caller pattern: `effect-smol/packages/effect/src/Stream.ts:1540-1558` (`Stream.fromEventListener`).

## Why isolated

Both changes are inside this file. The `subscribable` removal is a public API drop, but downstream code (e.g. `tests/index.test.ts`'s `subscribableAtom` helper, which is round 3 work anyway) can switch to the `Atom.make(stream(...), { initialValue: initialValue(...) })` recipe in one line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
