### PR TITLE
Effect v4 r2: client.ts Exit.match + null arg normalization

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -1,4 +1,9 @@
-import { Zero, type ZeroOptions, type Schema as ZeroSchema, type Transaction as ZeroTransaction } from "@rocicorp/zero";
+import {
+  Zero,
+  type ZeroOptions,
+  type Schema as ZeroSchema,
+  type Transaction as ZeroTransaction,
+} from "@rocicorp/zero";
 import * as Cause from "effect/Cause";
 import * as Data from "effect/Data";
 import * as Effect from "effect/Effect";
@@ -15,37 +20,42 @@ type ClientTransactionContext<TSchema extends ZeroSchema> = Omit<
   "use"
 >;
 
-export const make = Effect.fn(function* <TSchema extends ZeroSchema, TMutators extends Mutators.AnyMutators>(
+export const make = Effect.fn(function* <
+  TSchema extends ZeroSchema,
+  TMutators extends Mutators.AnyMutators,
+>(
   transaction: ClientTransactionContext<TSchema>,
   mutators: TMutators,
-  options: Omit<ZeroOptions<TSchema, UnwrapMutators<TSchema, TMutators>>, "schema" | "mutators">,
+  options: Omit<
+    ZeroOptions<TSchema, UnwrapMutators<TSchema, TMutators>>,
+    "schema" | "mutators"
+  >,
 ) {
   const ctx =
     yield* Effect.context<
-      Exclude<Mutators.ExtractMutatorsRequirements<TMutators>, ClientTransaction.ClientTransaction>
+      Exclude<
+        Mutators.ExtractMutatorsRequirements<TMutators>,
+        ClientTransaction.ClientTransaction
+      >
     >();
 
-  function unwrapMutator<E>(mutator: Mutators.AnyMutator<Mutators.ExtractMutatorsRequirements<TMutators>, E>) {
-    return async (tx: ZeroTransaction<TSchema>, args: unknown, _ctx: unknown) => {
-      // Normalize JSON's `null` to `undefined` for `Schema.Void` decode.
-      //
-      // Zero's mutator-call dispatch unconditionally coerces the args slot via `args ?? null`
-      // when freezing pending mutations -- so an arg-less call (`mutator()`, where `args`
-      // is `undefined`) is stored, persisted, and replayed as `null`:
-      // https://github.com/rocicorp/mono/blob/05ab7f78047b5bb1cdfc0797bea8cf2537685c93/packages/replicache/src/replicache-impl.ts#L1521
-      //
-      // Effect v3's `Schema.Void` parser accepted any input unconditionally (its
-      // `VoidKeyword` case returned `Either.right(input)` like `Unknown`/`Any`), so
-      // `null` flowed through. v4's `Schema.Void` is strict: its AST uses
-      // `fromConst(this, undefined)` and rejects anything that isn't `=== undefined`
-      // with `Expected void, got null`.
-      //
-      // To preserve the v3 client behavior (arg-less mutators succeed) without
-      // weakening every mutator's payload schema, normalize the wire `null` back to
-      // `undefined` here before decoding.
-      const input = args === null ? undefined : args;
-      const exit = await Schema.decodeUnknownEffect(mutator[Mutators.MutatorSchemaSymbol])(input).pipe(
-        Effect.catchTag("SchemaError", (e) => Effect.fail(new ClientArgsParseError({ cause: Cause.fail(e) }))),
+  function unwrapMutator<E>(
+    mutator: Mutators.AnyMutator<
+      Mutators.ExtractMutatorsRequirements<TMutators>,
+      E
+    >,
+  ) {
+    return async (
+      tx: ZeroTransaction<TSchema>,
+      args: unknown,
+      _ctx: unknown,
+    ) => {
+      const exit = await Schema.decodeUnknownEffect(
+        mutator[Mutators.MutatorSchemaSymbol],
+      )(args).pipe(
+        Effect.catchTag("SchemaError", (e) =>
+          Effect.fail(new ClientArgsParseError({ cause: Cause.fail(e) })),
+        ),
         Effect.flatMap(mutator),
         Effect.provideService(transaction, tx),
         Effect.runPromiseExitWith(ctx),
@@ -59,7 +69,10 @@ export const make = Effect.fn(function* <TSchema extends ZeroSchema, TMutators e
   }
 
   const unwrappedMutators = Rec.map(mutators, (v) =>
-    Match.value(v).pipe(Match.when(Predicate.isFunction, unwrapMutator), Match.orElse(Rec.map(unwrapMutator))),
+    Match.value(v).pipe(
+      Match.when(Predicate.isFunction, unwrapMutator),
+      Match.orElse(Rec.map(unwrapMutator)),
+    ),
   ) as ZeroOptions<TSchema, UnwrapMutators<TSchema, TMutators>>["mutators"];
 
   return yield* Effect.acquireRelease(
@@ -74,14 +87,23 @@ export const make = Effect.fn(function* <TSchema extends ZeroSchema, TMutators e
   );
 });
 
-type UnwrapMutator<TSchema extends ZeroSchema, TMutators extends Mutators.AnyMutator> = Parameters<TMutators> extends []
-  ? (transaction: ZeroTransaction<TSchema>) => Promise<void>
-  : (
-      transaction: ZeroTransaction<TSchema>,
-      args: Schema.Codec.Encoded<TMutators[typeof Mutators.MutatorSchemaSymbol]>,
-    ) => Promise<void>;
+type UnwrapMutator<
+  TSchema extends ZeroSchema,
+  TMutators extends Mutators.AnyMutator,
+> =
+  Parameters<TMutators> extends []
+    ? (transaction: ZeroTransaction<TSchema>) => Promise<void>
+    : (
+        transaction: ZeroTransaction<TSchema>,
+        args: Schema.Codec.Encoded<
+          TMutators[typeof Mutators.MutatorSchemaSymbol]
+        >,
+      ) => Promise<void>;
 
-type UnwrapMutators<TSchema extends ZeroSchema, TMutators extends Mutators.AnyMutators> = {
+type UnwrapMutators<
+  TSchema extends ZeroSchema,
+  TMutators extends Mutators.AnyMutators,
+> = {
   [A in keyof TMutators]: TMutators[A] extends Mutators.AnyMutator
     ? UnwrapMutator<TSchema, TMutators[A]>
     : {
@@ -91,6 +113,8 @@ type UnwrapMutators<TSchema extends ZeroSchema, TMutators extends Mutators.AnyMu
       };
 } & {};
 
-export class ClientArgsParseError extends Data.TaggedError("ClientArgsParseError")<{
+export class ClientArgsParseError extends Data.TaggedError(
+  "ClientArgsParseError",
+)<{
   readonly cause: Cause.Cause<Schema.SchemaError>;
 }> {}

--- a/src/client.ts
+++ b/src/client.ts
@@ -35,13 +35,11 @@ export const make = Effect.fn(function* <TSchema extends ZeroSchema, TMutators e
         Effect.provideService(transaction, tx),
         Effect.runPromiseExitWith(ctx),
       );
-      return Exit.match(exit, {
-        onSuccess: (v) => v,
-        onFailure: (c) => {
-          // Extract underlying error bypassing FiberFailure
-          throw Cause.squash(c);
-        },
-      });
+      if (Exit.isFailure(exit)) {
+        // Extract underlying error bypassing FiberFailure
+        throw Cause.squash(exit.cause);
+      }
+      return exit.value;
     };
   }
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -27,7 +27,22 @@ export const make = Effect.fn(function* <TSchema extends ZeroSchema, TMutators e
 
   function unwrapMutator<E>(mutator: Mutators.AnyMutator<Mutators.ExtractMutatorsRequirements<TMutators>, E>) {
     return async (tx: ZeroTransaction<TSchema>, args: unknown, _ctx: unknown) => {
-      // Normalize JSON's `null` to `undefined` so `Schema.Void` validates the "no args" case.
+      // Normalize JSON's `null` to `undefined` for `Schema.Void` decode.
+      //
+      // Zero's mutator-call dispatch unconditionally coerces the args slot via `args ?? null`
+      // when freezing pending mutations -- so an arg-less call (`mutator()`, where `args`
+      // is `undefined`) is stored, persisted, and replayed as `null`:
+      // https://github.com/rocicorp/mono/blob/05ab7f78047b5bb1cdfc0797bea8cf2537685c93/packages/replicache/src/replicache-impl.ts#L1521
+      //
+      // Effect v3's `Schema.Void` parser accepted any input unconditionally (its
+      // `VoidKeyword` case returned `Either.right(input)` like `Unknown`/`Any`), so
+      // `null` flowed through. v4's `Schema.Void` is strict: its AST uses
+      // `fromConst(this, undefined)` and rejects anything that isn't `=== undefined`
+      // with `Expected void, got null`.
+      //
+      // To preserve the v3 client behavior (arg-less mutators succeed) without
+      // weakening every mutator's payload schema, normalize the wire `null` back to
+      // `undefined` here before decoding.
       const input = args === null ? undefined : args;
       const exit = await Schema.decodeUnknownEffect(mutator[Mutators.MutatorSchemaSymbol])(input).pipe(
         Effect.catchTag("SchemaError", (e) => Effect.fail(new ClientArgsParseError({ cause: Cause.fail(e) }))),

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,9 +1,4 @@
-import {
-  Zero,
-  type ZeroOptions,
-  type Schema as ZeroSchema,
-  type Transaction as ZeroTransaction,
-} from "@rocicorp/zero";
+import { Zero, type ZeroOptions, type Schema as ZeroSchema, type Transaction as ZeroTransaction } from "@rocicorp/zero";
 import * as Cause from "effect/Cause";
 import * as Data from "effect/Data";
 import * as Effect from "effect/Effect";
@@ -20,42 +15,20 @@ type ClientTransactionContext<TSchema extends ZeroSchema> = Omit<
   "use"
 >;
 
-export const make = Effect.fn(function* <
-  TSchema extends ZeroSchema,
-  TMutators extends Mutators.AnyMutators,
->(
+export const make = Effect.fn(function* <TSchema extends ZeroSchema, TMutators extends Mutators.AnyMutators>(
   transaction: ClientTransactionContext<TSchema>,
   mutators: TMutators,
-  options: Omit<
-    ZeroOptions<TSchema, UnwrapMutators<TSchema, TMutators>>,
-    "schema" | "mutators"
-  >,
+  options: Omit<ZeroOptions<TSchema, UnwrapMutators<TSchema, TMutators>>, "schema" | "mutators">,
 ) {
   const ctx =
     yield* Effect.context<
-      Exclude<
-        Mutators.ExtractMutatorsRequirements<TMutators>,
-        ClientTransaction.ClientTransaction
-      >
+      Exclude<Mutators.ExtractMutatorsRequirements<TMutators>, ClientTransaction.ClientTransaction>
     >();
 
-  function unwrapMutator<E>(
-    mutator: Mutators.AnyMutator<
-      Mutators.ExtractMutatorsRequirements<TMutators>,
-      E
-    >,
-  ) {
-    return async (
-      tx: ZeroTransaction<TSchema>,
-      args: unknown,
-      _ctx: unknown,
-    ) => {
-      const exit = await Schema.decodeUnknownEffect(
-        mutator[Mutators.MutatorSchemaSymbol],
-      )(args).pipe(
-        Effect.catchTag("SchemaError", (e) =>
-          Effect.fail(new ClientArgsParseError({ cause: Cause.fail(e) })),
-        ),
+  function unwrapMutator<E>(mutator: Mutators.AnyMutator<Mutators.ExtractMutatorsRequirements<TMutators>, E>) {
+    return async (tx: ZeroTransaction<TSchema>, args: unknown, _ctx: unknown) => {
+      const exit = await Schema.decodeUnknownEffect(mutator[Mutators.MutatorSchemaSymbol])(args).pipe(
+        Effect.catchTag("SchemaError", (e) => Effect.fail(new ClientArgsParseError({ cause: Cause.fail(e) }))),
         Effect.flatMap(mutator),
         Effect.provideService(transaction, tx),
         Effect.runPromiseExitWith(ctx),
@@ -69,10 +42,7 @@ export const make = Effect.fn(function* <
   }
 
   const unwrappedMutators = Rec.map(mutators, (v) =>
-    Match.value(v).pipe(
-      Match.when(Predicate.isFunction, unwrapMutator),
-      Match.orElse(Rec.map(unwrapMutator)),
-    ),
+    Match.value(v).pipe(Match.when(Predicate.isFunction, unwrapMutator), Match.orElse(Rec.map(unwrapMutator))),
   ) as ZeroOptions<TSchema, UnwrapMutators<TSchema, TMutators>>["mutators"];
 
   return yield* Effect.acquireRelease(
@@ -87,23 +57,14 @@ export const make = Effect.fn(function* <
   );
 });
 
-type UnwrapMutator<
-  TSchema extends ZeroSchema,
-  TMutators extends Mutators.AnyMutator,
-> =
-  Parameters<TMutators> extends []
-    ? (transaction: ZeroTransaction<TSchema>) => Promise<void>
-    : (
-        transaction: ZeroTransaction<TSchema>,
-        args: Schema.Codec.Encoded<
-          TMutators[typeof Mutators.MutatorSchemaSymbol]
-        >,
-      ) => Promise<void>;
+type UnwrapMutator<TSchema extends ZeroSchema, TMutators extends Mutators.AnyMutator> = Parameters<TMutators> extends []
+  ? (transaction: ZeroTransaction<TSchema>) => Promise<void>
+  : (
+      transaction: ZeroTransaction<TSchema>,
+      args: Schema.Codec.Encoded<TMutators[typeof Mutators.MutatorSchemaSymbol]>,
+    ) => Promise<void>;
 
-type UnwrapMutators<
-  TSchema extends ZeroSchema,
-  TMutators extends Mutators.AnyMutators,
-> = {
+type UnwrapMutators<TSchema extends ZeroSchema, TMutators extends Mutators.AnyMutators> = {
   [A in keyof TMutators]: TMutators[A] extends Mutators.AnyMutator
     ? UnwrapMutator<TSchema, TMutators[A]>
     : {
@@ -113,8 +74,6 @@ type UnwrapMutators<
       };
 } & {};
 
-export class ClientArgsParseError extends Data.TaggedError(
-  "ClientArgsParseError",
-)<{
+export class ClientArgsParseError extends Data.TaggedError("ClientArgsParseError")<{
   readonly cause: Cause.Cause<Schema.SchemaError>;
 }> {}

--- a/src/client.ts
+++ b/src/client.ts
@@ -27,15 +27,20 @@ export const make = Effect.fn(function* <TSchema extends ZeroSchema, TMutators e
 
   function unwrapMutator<E>(mutator: Mutators.AnyMutator<Mutators.ExtractMutatorsRequirements<TMutators>, E>) {
     return async (tx: ZeroTransaction<TSchema>, args: unknown, _ctx: unknown) => {
-      const exit = await Schema.decodeUnknownEffect(mutator[Mutators.MutatorSchemaSymbol])(args).pipe(
+      // Normalize JSON's `null` to `undefined` so `Schema.Void` validates the "no args" case.
+      const input = args === null ? undefined : args;
+      const exit = await Schema.decodeUnknownEffect(mutator[Mutators.MutatorSchemaSymbol])(input).pipe(
         Effect.catchTag("SchemaError", (e) => Effect.fail(new ClientArgsParseError({ cause: Cause.fail(e) }))),
         Effect.flatMap(mutator),
         Effect.provideService(transaction, tx),
         Effect.runPromiseExitWith(ctx),
       );
-      return Exit.getOrElse(exit, (c) => {
-        // Extract underlying error bypassing FiberFailure
-        throw Cause.squash(c);
+      return Exit.match(exit, {
+        onSuccess: (v) => v,
+        onFailure: (c) => {
+          // Extract underlying error bypassing FiberFailure
+          throw Cause.squash(c);
+        },
       });
     };
   }


### PR DESCRIPTION
## Summary

Round 2 — two file-local v4 fixes in `src/client.ts`. **Branches off #38 (base PR).**

## Changes

### 1. `Exit.getOrElse` → `Exit.isFailure` guard

v3's `Exit.getOrElse(exit, onFailure)` was removed in v4. The canonical v4 replacement (per effect-smol's own usage) is **not** `Exit.match` with an identity `onSuccess`, but rather an `Exit.isFailure` guard with direct `.value` / `.cause` access:

```ts
if (Exit.isFailure(exit)) {
  throw Cause.squash(exit.cause);
}
return exit.value;
```

**v3 ↔ v4 reference:**
- v3 `Exit.getOrElse`: `effect@3.19.3/packages/effect/src/Exit.ts:252-255` (signature) and `effect@3.19.3/packages/effect/src/internal/core.ts:2571-2581` (impl). **Removed in v4.**
- v3 effect's own use of `Exit.getOrElse` in src/test: only one mention, a JSDoc example at `effect@3.19.3/packages/effect/src/Effect.ts:5869`. Effect itself never used the function outside docs.
- v4 effect-smol's "extract value or throw" idiom — used consistently:
  - `effect-smol/packages/effect/src/SchemaParser.ts:122-130` (`asserts`)
  - `effect-smol/packages/effect/src/SchemaParser.ts:387-397` (`asResult`)
  - `effect-smol/packages/effect/src/Stream.ts:10570-10578` (async iterator)
  - `effect-smol/packages/effect/src/unstable/reactivity/AsyncResult.ts:794-800`

### 2. Normalize JSON `null` → `undefined` for `Schema.Void`

v3 `Schema.Void` accepted any value (the `VoidKeyword` parser returned `Either.right(...)` unconditionally). v4 `Schema.Void` requires strict `=== undefined`, so JSON's `null` (the wire shape Zero passes for arg-less mutators) now fails decoding. Alias `args === null ? undefined : args` before decoding to preserve v3-equivalent behavior.

**v3 ↔ v4 reference:**
- v3 behavior: `effect@3.19.3/packages/effect/src/ParseResult.ts:856-863` — `VoidKeyword` parser: `return Either.right(input)` unconditionally.
- v4 behavior: `effect-smol/packages/effect/src/SchemaAST.ts:706-720` and `:3102-3115` — `Schema.Void` AST uses `fromConst(this, undefined)` which compares input strictly to `undefined`.

## Why isolated

Both changes sit inside `unwrapMutator`. No exports change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
