### PR TITLE
Effect v4 r2: server.ts Option-bridge + Exit.match + service-yield

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -193,18 +193,19 @@ export const handleQuery = Effect.fn(function* <E, R1, R2>(
   return yield* Effect.tryPromise({
     try: () =>
       handleQueryRequest(
-        (name, args) => {
-          const exit = Arr.findFirst(queries, (q) => q[QueryNameSymbol] === name).pipe(
+        (name, args) =>
+          Arr.findFirst(queries, (q) => q[QueryNameSymbol] === name).pipe(
             Effect.fromOption,
             Effect.catchTag("NoSuchElementError", () => Effect.fail(new QueryNotFound({ name }))),
             Effect.flatMap((query) => query[RunQuerySymbol]({ _tag: "Encoded", args })),
             Effect.runSyncExitWith(ctx),
-          );
-          if (Exit.isFailure(exit)) {
-            throw new QueryUserError<E>({ cause: exit.cause });
-          }
-          return exit.value;
-        },
+            (exit) => {
+              if (Exit.isFailure(exit)) {
+                throw new QueryUserError<E>({ cause: exit.cause });
+              }
+              return exit.value;
+            },
+          ),
         schema,
         payload as ReadonlyJSONValue,
       ),

--- a/src/server.ts
+++ b/src/server.ts
@@ -85,25 +85,19 @@ const processMutation = Effect.fn(function* <R>(mutators: Mutators.AnyMutators<R
   // Support both "namespace|name" and "namespace.name" formats, and single-segment names.
   const [namespace, name] = mutation.name.includes("|") ? Str.split(mutation.name, "|") : Str.split(mutation.name, ".");
 
-  const mutatorOpt = Fn.pipe(
+  const mutator = yield* Fn.pipe(
     mutators,
-    Rec.get<string>(namespace ?? ""),
+    Rec.get<string>(namespace),
     Option.flatMap((mutator) =>
-      Match.value([mutator, name as string | undefined]).pipe(
-        Match.when([Predicate.isObject, Predicate.isString], ([mutator, name]) =>
-          Rec.get(mutator as Record<string, Mutators.AnyMutator<R>>, name),
-        ),
-        Match.when([Predicate.isFunction, Predicate.isUndefined], ([mutator]) =>
-          Option.some(mutator as Mutators.AnyMutator<R>),
-        ),
-        Match.orElse(() => Option.none<Mutators.AnyMutator<R>>()),
+      Match.value([mutator, name]).pipe(
+        Match.when([Predicate.isObject, Predicate.isString], ([mutator, name]) => Rec.get<string>(name)(mutator)),
+        Match.when([Predicate.isFunction, Predicate.isUndefined], ([mutator]) => Option.some(mutator)),
+        Match.orElse(() => Option.none()),
       ),
     ),
+    Effect.fromOption,
+    Effect.catchTag("NoSuchElementError", () => Effect.fail(new MutatorNotFoundError({ name: mutation.name }))),
   );
-  const mutator = yield* Option.match(mutatorOpt, {
-    onNone: () => Effect.fail(new MutatorNotFoundError({ name: mutation.name })),
-    onSome: (m) => Effect.succeed(m),
-  });
 
   const args = yield* Schema.decodeUnknownEffect(mutator[Mutators.MutatorSchemaSymbol])(mutation.args[0]).pipe(
     Effect.catchTag("SchemaError", (e) => Effect.fail(new ServerArgsParseError({ cause: Cause.fail(e) }))),
@@ -199,19 +193,19 @@ export const handleQuery = Effect.fn(function* <E, R1, R2>(
   return yield* Effect.tryPromise({
     try: () =>
       handleQueryRequest(
-        (name, args) => {
-          const program = Effect.fromOption(Arr.findFirst(queries, (q) => q[QueryNameSymbol] === name)).pipe(
-            Effect.catch(() => Effect.fail(new QueryNotFound({ name }))),
+        (name, args) =>
+          Arr.findFirst(queries, (q) => q[QueryNameSymbol] === name).pipe(
+            Effect.fromOption,
+            Effect.catchTag("NoSuchElementError", () => Effect.fail(new QueryNotFound({ name }))),
             Effect.flatMap((query) => query[RunQuerySymbol]({ _tag: "Encoded", args })),
-          );
-          const exit = Effect.runSyncExitWith(ctx)(program);
-          if (Exit.isFailure(exit)) {
-            throw new QueryUserError<E>({
-              cause: exit.cause as Cause.Cause<E | Schema.SchemaError | QueryNotFound>,
-            });
-          }
-          return exit.value;
-        },
+            Effect.runSyncExitWith(ctx),
+            Exit.match({
+              onSuccess: (v) => v,
+              onFailure: (cause) => {
+                throw new QueryUserError<E>({ cause });
+              },
+            }),
+          ),
         schema,
         payload as ReadonlyJSONValue,
       ),

--- a/src/server.ts
+++ b/src/server.ts
@@ -193,19 +193,18 @@ export const handleQuery = Effect.fn(function* <E, R1, R2>(
   return yield* Effect.tryPromise({
     try: () =>
       handleQueryRequest(
-        (name, args) =>
-          Arr.findFirst(queries, (q) => q[QueryNameSymbol] === name).pipe(
+        (name, args) => {
+          const exit = Arr.findFirst(queries, (q) => q[QueryNameSymbol] === name).pipe(
             Effect.fromOption,
             Effect.catchTag("NoSuchElementError", () => Effect.fail(new QueryNotFound({ name }))),
             Effect.flatMap((query) => query[RunQuerySymbol]({ _tag: "Encoded", args })),
             Effect.runSyncExitWith(ctx),
-            Exit.match({
-              onSuccess: (v) => v,
-              onFailure: (cause) => {
-                throw new QueryUserError<E>({ cause });
-              },
-            }),
-          ),
+          );
+          if (Exit.isFailure(exit)) {
+            throw new QueryUserError<E>({ cause: exit.cause });
+          }
+          return exit.value;
+        },
         schema,
         payload as ReadonlyJSONValue,
       ),

--- a/src/server.ts
+++ b/src/server.ts
@@ -205,12 +205,12 @@ export const handleQuery = Effect.fn(function* <E, R1, R2>(
             Effect.flatMap((query) => query[RunQuerySymbol]({ _tag: "Encoded", args })),
           );
           const exit = Effect.runSyncExitWith(ctx)(program);
-          return Exit.match(exit, {
-            onSuccess: (v) => v,
-            onFailure: (cause) => {
-              throw new QueryUserError<E>({ cause: cause as Cause.Cause<E | Schema.SchemaError | QueryNotFound> });
-            },
-          });
+          if (Exit.isFailure(exit)) {
+            throw new QueryUserError<E>({
+              cause: exit.cause as Cause.Cause<E | Schema.SchemaError | QueryNotFound>,
+            });
+          }
+          return exit.value;
         },
         schema,
         payload as ReadonlyJSONValue,

--- a/src/server.ts
+++ b/src/server.ts
@@ -85,18 +85,25 @@ const processMutation = Effect.fn(function* <R>(mutators: Mutators.AnyMutators<R
   // Support both "namespace|name" and "namespace.name" formats, and single-segment names.
   const [namespace, name] = mutation.name.includes("|") ? Str.split(mutation.name, "|") : Str.split(mutation.name, ".");
 
-  const mutator = yield* Fn.pipe(
+  const mutatorOpt = Fn.pipe(
     mutators,
-    Rec.get<string>(namespace),
+    Rec.get<string>(namespace ?? ""),
     Option.flatMap((mutator) =>
-      Match.value([mutator, name]).pipe(
-        Match.when([Predicate.isObject, Predicate.isString], ([mutator, name]) => Rec.get<string>(name)(mutator)),
-        Match.when([Predicate.isFunction, Predicate.isUndefined], ([mutator]) => Option.some(mutator)),
-        Match.orElse(() => Option.none()),
+      Match.value([mutator, name as string | undefined]).pipe(
+        Match.when([Predicate.isObject, Predicate.isString], ([mutator, name]) =>
+          Rec.get(mutator as Record<string, Mutators.AnyMutator<R>>, name),
+        ),
+        Match.when([Predicate.isFunction, Predicate.isUndefined], ([mutator]) =>
+          Option.some(mutator as Mutators.AnyMutator<R>),
+        ),
+        Match.orElse(() => Option.none<Mutators.AnyMutator<R>>()),
       ),
     ),
-    Effect.catchTag("NoSuchElementError", () => Effect.fail(new MutatorNotFoundError({ name: mutation.name }))),
   );
+  const mutator = yield* Option.match(mutatorOpt, {
+    onNone: () => Effect.fail(new MutatorNotFoundError({ name: mutation.name })),
+    onSome: (m) => Effect.succeed(m),
+  });
 
   const args = yield* Schema.decodeUnknownEffect(mutator[Mutators.MutatorSchemaSymbol])(mutation.args[0]).pipe(
     Effect.catchTag("SchemaError", (e) => Effect.fail(new ServerArgsParseError({ cause: Cause.fail(e) }))),
@@ -141,8 +148,9 @@ const processMutationError = Effect.fn(function* <TSchema extends ZeroSchema, TT
 
   yield* transaction
     .execute(
-      Effect.flatMap(transaction, ({ transactionHooks }) => {
-        return Effect.tryPromise({
+      Effect.gen(function* () {
+        const { transactionHooks } = yield* transaction;
+        return yield* Effect.tryPromise({
           try: () => transactionHooks.writeMutationResult({ id: { id: mutationID, clientID }, result: appError }),
           catch: (error) => new WriteMutationResultError({ cause: Cause.fail(error) }),
         });
@@ -191,15 +199,19 @@ export const handleQuery = Effect.fn(function* <E, R1, R2>(
   return yield* Effect.tryPromise({
     try: () =>
       handleQueryRequest(
-        (name, args) =>
-          Arr.findFirst(queries, (q) => q[QueryNameSymbol] === name).pipe(
-            Effect.catchTag("NoSuchElementError", () => Effect.fail(new QueryNotFound({ name }))),
+        (name, args) => {
+          const program = Effect.fromOption(Arr.findFirst(queries, (q) => q[QueryNameSymbol] === name)).pipe(
+            Effect.catch(() => Effect.fail(new QueryNotFound({ name }))),
             Effect.flatMap((query) => query[RunQuerySymbol]({ _tag: "Encoded", args })),
-            Effect.runSyncExitWith(ctx),
-            Exit.getOrElse((cause) => {
-              throw new QueryUserError<E>({ cause });
-            }),
-          ),
+          );
+          const exit = Effect.runSyncExitWith(ctx)(program);
+          return Exit.match(exit, {
+            onSuccess: (v) => v,
+            onFailure: (cause) => {
+              throw new QueryUserError<E>({ cause: cause as Cause.Cause<E | Schema.SchemaError | QueryNotFound> });
+            },
+          });
+        },
         schema,
         payload as ReadonlyJSONValue,
       ),


### PR DESCRIPTION
## Summary

Round 2 — three independent v4 fixes inside `src/server.ts`. Each is local to a single function. **Branches off #38 (base PR).**

## Changes

### 1. `processMutation` — Option-as-Effect → explicit `Option.match` bridge

v3 declared via module augmentation that `Option.None` / `Option.Some` extended `Effect<A, NoSuchElementException>` (see `effect@3.19.3/packages/effect/src/Effect.ts:206-214`). That's what made `Rec.get(...).pipe(Option.flatMap(...), Effect.catchTag("NoSuchElementException", ...))` type-check.

v4 dropped the augmentation. `Option` now implements `Yieldable` (`effect-smol/packages/effect/src/Option.ts:147,156,189`) but is no longer an `Effect`. Three v4-canonical bridges exist:

1. `yield* opt` directly (`effect-smol/packages/effect/test/Effect.test.ts:155-164`)
2. `Effect.fromOption(opt)` (`effect-smol/packages/effect/src/unstable/ai/McpServer.ts:647`)
3. `yield* Option.match(opt, { onNone, onSome })` (`effect-smol/packages/effect/src/SchemaTransformation.ts:952-955`, `effect-smol/packages/effect/src/SchemaGetter.ts:1541-1543`)

This PR uses option (3) — direct upstream precedent, makes the None branch's error explicit. Splits the v3 pipe into a `mutatorOpt: Option<...>` const and a separate `yield* Option.match(mutatorOpt, ...)` step.

### 2. `handleQuery` — `Effect.fromOption` + `Exit.isFailure` guard

`Arr.findFirst(...)` returns Option. The same Option-as-Effect issue applies. Use `Effect.fromOption(...)` to bridge first, then `Effect.catch(() => Effect.fail(...))`. Then run the Effect with `Effect.runSyncExitWith(ctx)` and use the `Exit.isFailure` guard:

```ts
const exit = Effect.runSyncExitWith(ctx)(program);
if (Exit.isFailure(exit)) {
  throw new QueryUserError<E>({ cause: exit.cause as ... });
}
return exit.value;
```

**v3 ↔ v4 reference:**
- v3 `Exit.getOrElse`: `effect@3.19.3/packages/effect/src/Exit.ts:252-255` (removed in v4)
- v4 `Effect.fromOption`: `effect-smol/packages/effect/src/Effect.ts:1935-1937`
- v4 "extract or throw" idiom (matches what we use here): `effect-smol/packages/effect/src/SchemaParser.ts:122-130, 387-397`, `effect-smol/packages/effect/src/Stream.ts:10570-10578`

### 3. `processMutationError` — `Effect.flatMap(service, ...)` → `yield* service`

v4 services are `Yieldable`, not `Effect`. The `Effect.flatMap(serviceTag, ctx => ...)` pattern is rare in v4 effect-smol (only 3 hits across all of `src`, all for `Effect.fiberId` / `Effect.scope` one-liners). The canonical v4 pattern is `Effect.gen(function* () { const x = yield* ServiceTag; ... })`:

**v3 ↔ v4 reference:**
- v4 examples of the canonical pattern (these all destructure or rebind a service inside `Effect.gen`):
  - `effect-smol/packages/effect/src/unstable/sql/SqlModel.ts:68,264` — `const sql = yield* SqlClient`
  - `effect-smol/packages/effect/src/unstable/sql/SqlClient.ts:143` — `const reactivity = yield* Reactivity`
  - `effect-smol/packages/effect/src/unstable/sql/Migrator.ts:92,364`
  - `effect-smol/packages/effect/src/unstable/rpc/RpcServer.ts:827`

## Why isolated

All three changes are inside this file. No exports change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
