### PR TITLE
Effect v4 r2: server-transaction.ts Exit.match

### DIFF
--- a/src/server-transaction.ts
+++ b/src/server-transaction.ts
@@ -68,15 +68,18 @@ export const make = <const Id extends string, TSchema extends ZeroSchema, TTrans
             (effect) => Effect.runPromiseExitWith(ctx)(effect, { signal }),
           );
           Deferred.doneUnsafe(result, exit);
-          return Exit.getOrElse(exit, () => {
-            // This error's purpose is to differentiate between "external" errors
-            // that originate from the user-defined mutator code and "internal" errors
-            // that originate from our own code and the Zero API.
-            // Both types are caught in the "catch" block below, but at this point we only need to handle
-            // the "internal" errors wrapping them in a `ZeroDatabaseError`, because "external" errors
-            // are already covered by passing the Exit result to the Deferred, which is why
-            // we have the ServerTransactionUserError silenced below in the pipe.
-            throw new ServerTransactionUserError();
+          return Exit.match(exit, {
+            onSuccess: (v) => v,
+            onFailure: () => {
+              // This error's purpose is to differentiate between "external" errors
+              // that originate from the user-defined mutator code and "internal" errors
+              // that originate from our own code and the Zero API.
+              // Both types are caught in the "catch" block below, but at this point we only need to handle
+              // the "internal" errors wrapping them in a `ZeroDatabaseError`, because "external" errors
+              // are already covered by passing the Exit result to the Deferred, which is why
+              // we have the ServerTransactionUserError silenced below in the pipe.
+              throw new ServerTransactionUserError();
+            },
           });
         }, transactionInput),
       catch: (error) => {

--- a/src/server-transaction.ts
+++ b/src/server-transaction.ts
@@ -68,19 +68,17 @@ export const make = <const Id extends string, TSchema extends ZeroSchema, TTrans
             (effect) => Effect.runPromiseExitWith(ctx)(effect, { signal }),
           );
           Deferred.doneUnsafe(result, exit);
-          return Exit.match(exit, {
-            onSuccess: (v) => v,
-            onFailure: () => {
-              // This error's purpose is to differentiate between "external" errors
-              // that originate from the user-defined mutator code and "internal" errors
-              // that originate from our own code and the Zero API.
-              // Both types are caught in the "catch" block below, but at this point we only need to handle
-              // the "internal" errors wrapping them in a `ZeroDatabaseError`, because "external" errors
-              // are already covered by passing the Exit result to the Deferred, which is why
-              // we have the ServerTransactionUserError silenced below in the pipe.
-              throw new ServerTransactionUserError();
-            },
-          });
+          if (Exit.isFailure(exit)) {
+            // This error's purpose is to differentiate between "external" errors
+            // that originate from the user-defined mutator code and "internal" errors
+            // that originate from our own code and the Zero API.
+            // Both types are caught in the "catch" block below, but at this point we only need to handle
+            // the "internal" errors wrapping them in a `ZeroDatabaseError`, because "external" errors
+            // are already covered by passing the Exit result to the Deferred, which is why
+            // we have the ServerTransactionUserError silenced below in the pipe.
+            throw new ServerTransactionUserError();
+          }
+          return exit.value;
         }, transactionInput),
       catch: (error) => {
         if (ServerTransactionUserError.is(error)) {


### PR DESCRIPTION
## Summary

Round 2 — small file-local fix in `src/server-transaction.ts`. **Branches off #38 (base PR).**

## Changes

`Exit.getOrElse(exit, onFailure)` was removed in v4. Replace with the v4-canonical `Exit.isFailure` guard pattern (effect-smol's own idiom for "extract or throw"):

```ts
if (Exit.isFailure(exit)) {
  throw new ServerTransactionUserError();
}
return exit.value;
```

**v3 ↔ v4 reference:**
- v3 `Exit.getOrElse`: `effect@3.19.3/packages/effect/src/Exit.ts:252-255` (signature) and `effect@3.19.3/packages/effect/src/internal/core.ts:2571-2581` (impl). **Removed in v4.**
- v3 effect's own use of `Exit.getOrElse` in src/test: only one mention, a JSDoc example at `effect@3.19.3/packages/effect/src/Effect.ts:5869`. The library itself never used `getOrElse` outside docs.
- v4 effect-smol's `Exit.isFailure` guard pattern for "extract or throw":
  - `effect-smol/packages/effect/src/SchemaParser.ts:122-130` (`asserts`)
  - `effect-smol/packages/effect/src/SchemaParser.ts:387-397` (`asResult`)
  - `effect-smol/packages/effect/src/Stream.ts:10570-10578` (async iterator)

## Out of scope (deferred to round 3)

The remaining v3 patterns in this file — `Context.Tag` → `Context.Service`, `Context.TagClass` → `Context.Key`, the `Service.use` overload collision cast — are cross-cutting with `client-transaction.ts` (the producer of the type that flows into this file's `make` parameter), so they must land together as a coordinated PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
