### PR TITLE
Effect v4 r3a: canonical transaction services with module helpers

### DIFF
--- a/src/client-transaction.ts
+++ b/src/client-transaction.ts
@@ -3,51 +3,44 @@ import * as Cause from "effect/Cause";
 import * as Context from "effect/Context";
 import * as Data from "effect/Data";
 import * as Effect from "effect/Effect";
-import type * as Types from "effect/Types";
 
-// Self-type anchor for the factory-built Tag.
-//
-// v4's `Context.Service<Self, Shape>` requires a nominal `Self` marker. For module-level
-// Tags this is just the class itself (`class X extends Context.Service<X, S>()(...) {}`),
-// but our Tag is built per-call inside `make`, so the local class can't double as the Self
-// for external references. We anchor to this shared interface instead. Matches the spirit
-// of `effect-smol/src/LayerMap.ts:307-374` where the helpers-extending interface threads
-// `Self` through `Context.ServiceClass<Self, Id, Shape>`; LayerMap asks callers to supply
-// `Self`, while we pre-bake it here so the factory keeps a simple `make(id, schema)` shape.
-export interface ClientTransaction {
-  readonly _tag: unique symbol;
-}
+type ClientTransactionIdentifier<Id extends string, TSchema extends ZeroSchema> = Context.ServiceClass.Shape<
+  Id,
+  ZeroTransaction<TSchema>
+>;
 
-export interface ClientTransactionTag<Id extends string, TSchema extends ZeroSchema>
-  extends Context.ServiceClass<ClientTransaction, Id, ZeroTransaction<TSchema>> {
+type ClientTransactionService<Id extends string, TSchema extends ZeroSchema> = Context.ServiceClass<
+  ClientTransactionIdentifier<Id, TSchema>,
+  Id,
+  ZeroTransaction<TSchema>
+> & {
+  readonly schema: TSchema;
   readonly usePromise: <A>(
     fn: (transaction: ZeroTransaction<TSchema>, options: { readonly signal: AbortSignal }) => PromiseLike<A>,
-  ) => Effect.Effect<A, ClientTransactionError, ClientTransaction>;
-  readonly schema: TSchema;
-}
+  ) => Effect.Effect<A, ClientTransactionError, ClientTransactionIdentifier<Id, TSchema>>;
+};
 
 export const make = <const Id extends string, TSchema extends ZeroSchema>(
   id: Id,
   schema: TSchema,
-): ClientTransactionTag<Id, TSchema> => {
-  class Tag extends Context.Service<ClientTransaction, ZeroTransaction<TSchema>>()(id) {}
-  // Mutate-via-Mutable-cast pattern from effect-smol/src/Layer/LayerMap.ts:307-374.
-  // Attaches the promise-based `usePromise` helper plus the `schema` field directly on the
-  // Service-derived class. We use `usePromise` rather than `use` so we don't shadow the
-  // inherited `Context.Service.use` (which has a different, Effect-callback shape).
-  const Tag_ = Tag as unknown as Types.Mutable<ClientTransactionTag<Id, TSchema>>;
-  Tag_.usePromise = <A>(
-    fn: (transaction: ZeroTransaction<TSchema>, options: { readonly signal: AbortSignal }) => PromiseLike<A>,
-  ) =>
-    Effect.gen(function* () {
-      const transaction = yield* Tag;
-      return yield* Effect.tryPromise({
-        try: (signal) => fn(transaction, { signal }),
-        catch: (error) => new ClientTransactionError({ cause: Cause.fail(error) }),
+): ClientTransactionService<Id, TSchema> => {
+  class ClientTransaction extends Context.Service<ClientTransaction, ZeroTransaction<TSchema>>()(id) {
+    static readonly schema = schema;
+
+    static usePromise<A>(
+      fn: (transaction: ZeroTransaction<TSchema>, options: { readonly signal: AbortSignal }) => PromiseLike<A>,
+    ) {
+      return Effect.gen(function* () {
+        const transaction = yield* ClientTransaction;
+        return yield* Effect.tryPromise({
+          try: (signal) => fn(transaction, { signal }),
+          catch: (error) => new ClientTransactionError({ cause: Cause.fail(error) }),
+        });
       });
-    });
-  Tag_.schema = schema;
-  return Tag_ as ClientTransactionTag<Id, TSchema>;
+    }
+  }
+
+  return ClientTransaction;
 };
 
 class ClientTransactionError extends Data.TaggedError("ClientTransactionError")<{

--- a/src/client-transaction.ts
+++ b/src/client-transaction.ts
@@ -3,26 +3,43 @@ import * as Cause from "effect/Cause";
 import * as Context from "effect/Context";
 import * as Data from "effect/Data";
 import * as Effect from "effect/Effect";
+import type * as Types from "effect/Types";
 
 // Necessary workaround for TS declaration generation
 export interface ClientTransaction {
   readonly _tag: unique symbol;
 }
 
-export const make = <const Id extends string, TSchema extends ZeroSchema>(id: Id, schema: TSchema) => {
-  const ClientTransaction = Context.Tag(id)<ClientTransaction, ZeroTransaction<TSchema>>();
+export interface ClientTransactionTag<Id extends string, TSchema extends ZeroSchema>
+  extends Context.ServiceClass<ClientTransaction, Id, ZeroTransaction<TSchema>> {
+  readonly usePromise: <A>(
+    fn: (transaction: ZeroTransaction<TSchema>, options: { readonly signal: AbortSignal }) => PromiseLike<A>,
+  ) => Effect.Effect<A, ClientTransactionError, ClientTransaction>;
+  readonly schema: TSchema;
+}
 
-  const use = <A>(
+export const make = <const Id extends string, TSchema extends ZeroSchema>(
+  id: Id,
+  schema: TSchema,
+): ClientTransactionTag<Id, TSchema> => {
+  class Tag extends Context.Service<ClientTransaction, ZeroTransaction<TSchema>>()(id) {}
+  // Mutate-via-Mutable-cast pattern from effect-smol/src/Layer/LayerMap.ts:307-374.
+  // Attaches the promise-based `usePromise` helper plus the `schema` field directly on the
+  // Service-derived class. We use `usePromise` rather than `use` so we don't shadow the
+  // inherited `Context.Service.use` (which has a different, Effect-callback shape).
+  const Tag_ = Tag as unknown as Types.Mutable<ClientTransactionTag<Id, TSchema>>;
+  Tag_.usePromise = <A>(
     fn: (transaction: ZeroTransaction<TSchema>, options: { readonly signal: AbortSignal }) => PromiseLike<A>,
   ) =>
-    Effect.flatMap(ClientTransaction, (transaction) =>
-      Effect.tryPromise({
+    Effect.gen(function* () {
+      const transaction = yield* Tag;
+      return yield* Effect.tryPromise({
         try: (signal) => fn(transaction, { signal }),
         catch: (error) => new ClientTransactionError({ cause: Cause.fail(error) }),
-      }),
-    );
-
-  return Object.assign(ClientTransaction, { use, schema });
+      });
+    });
+  Tag_.schema = schema;
+  return Tag_ as ClientTransactionTag<Id, TSchema>;
 };
 
 class ClientTransactionError extends Data.TaggedError("ClientTransactionError")<{

--- a/src/client-transaction.ts
+++ b/src/client-transaction.ts
@@ -15,9 +15,6 @@ type ClientTransactionService<Id extends string, TSchema extends ZeroSchema> = C
   ZeroTransaction<TSchema>
 > & {
   readonly schema: TSchema;
-  readonly usePromise: <A>(
-    fn: (transaction: ZeroTransaction<TSchema>, options: { readonly signal: AbortSignal }) => PromiseLike<A>,
-  ) => Effect.Effect<A, ClientTransactionError, ClientTransactionIdentifier<Id, TSchema>>;
 };
 
 export const make = <const Id extends string, TSchema extends ZeroSchema>(
@@ -26,22 +23,22 @@ export const make = <const Id extends string, TSchema extends ZeroSchema>(
 ): ClientTransactionService<Id, TSchema> => {
   class ClientTransaction extends Context.Service<ClientTransaction, ZeroTransaction<TSchema>>()(id) {
     static readonly schema = schema;
-
-    static usePromise<A>(
-      fn: (transaction: ZeroTransaction<TSchema>, options: { readonly signal: AbortSignal }) => PromiseLike<A>,
-    ) {
-      return Effect.gen(function* () {
-        const transaction = yield* ClientTransaction;
-        return yield* Effect.tryPromise({
-          try: (signal) => fn(transaction, { signal }),
-          catch: (error) => new ClientTransactionError({ cause: Cause.fail(error) }),
-        });
-      });
-    }
   }
 
   return ClientTransaction;
 };
+
+export const use = <TIdentifier, TSchema extends ZeroSchema, A>(
+  clientTransaction: Context.Service<TIdentifier, ZeroTransaction<TSchema>>,
+  fn: (transaction: ZeroTransaction<TSchema>, options: { readonly signal: AbortSignal }) => PromiseLike<A>,
+): Effect.Effect<A, ClientTransactionError, TIdentifier> =>
+  Effect.gen(function* () {
+    const transaction = yield* clientTransaction;
+    return yield* Effect.tryPromise({
+      try: (signal) => fn(transaction, { signal }),
+      catch: (error) => new ClientTransactionError({ cause: Cause.fail(error) }),
+    });
+  });
 
 class ClientTransactionError extends Data.TaggedError("ClientTransactionError")<{
   readonly cause: Cause.Cause<unknown>;

--- a/src/client-transaction.ts
+++ b/src/client-transaction.ts
@@ -5,7 +5,15 @@ import * as Data from "effect/Data";
 import * as Effect from "effect/Effect";
 import type * as Types from "effect/Types";
 
-// Necessary workaround for TS declaration generation
+// Self-type anchor for the factory-built Tag.
+//
+// v4's `Context.Service<Self, Shape>` requires a nominal `Self` marker. For module-level
+// Tags this is just the class itself (`class X extends Context.Service<X, S>()(...) {}`),
+// but our Tag is built per-call inside `make`, so the local class can't double as the Self
+// for external references. We anchor to this shared interface instead. Matches the spirit
+// of `effect-smol/src/LayerMap.ts:307-374` where the helpers-extending interface threads
+// `Self` through `Context.ServiceClass<Self, Id, Shape>`; LayerMap asks callers to supply
+// `Self`, while we pre-bake it here so the factory keeps a simple `make(id, schema)` shape.
 export interface ClientTransaction {
   readonly _tag: unique symbol;
 }

--- a/src/client.ts
+++ b/src/client.ts
@@ -8,23 +8,25 @@ import * as Match from "effect/Match";
 import * as Predicate from "effect/Predicate";
 import * as Rec from "effect/Record";
 import * as Schema from "effect/Schema";
-import type * as ClientTransaction from "./client-transaction.js";
 import * as Mutators from "./mutators.js";
 
-type ClientTransactionContext<TSchema extends ZeroSchema> = Omit<
-  ReturnType<typeof ClientTransaction.make<string, TSchema>>,
-  "use"
->;
+type ClientTransactionContext<TIdentifier, TSchema extends ZeroSchema> = Context.Key<
+  TIdentifier,
+  ZeroTransaction<TSchema>
+> & {
+  readonly schema: TSchema;
+};
 
-export const make = Effect.fn(function* <TSchema extends ZeroSchema, TMutators extends Mutators.AnyMutators>(
-  transaction: ClientTransactionContext<TSchema>,
+export const make = Effect.fn(function* <
+  TClientTransaction,
+  TSchema extends ZeroSchema,
+  TMutators extends Mutators.AnyMutators,
+>(
+  transaction: ClientTransactionContext<TClientTransaction, TSchema>,
   mutators: TMutators,
   options: Omit<ZeroOptions<TSchema, UnwrapMutators<TSchema, TMutators>>, "schema" | "mutators">,
 ) {
-  const ctx =
-    yield* Effect.context<
-      Exclude<Mutators.ExtractMutatorsRequirements<TMutators>, Context.Service.Identifier<typeof transaction>>
-    >();
+  const ctx = yield* Effect.context<Exclude<Mutators.ExtractMutatorsRequirements<TMutators>, TClientTransaction>>();
 
   function unwrapMutator<E>(mutator: Mutators.AnyMutator<Mutators.ExtractMutatorsRequirements<TMutators>, E>) {
     return async (tx: ZeroTransaction<TSchema>, args: unknown, _ctx: unknown) => {

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,5 +1,6 @@
 import { Zero, type ZeroOptions, type Schema as ZeroSchema, type Transaction as ZeroTransaction } from "@rocicorp/zero";
 import * as Cause from "effect/Cause";
+import type * as Context from "effect/Context";
 import * as Data from "effect/Data";
 import * as Effect from "effect/Effect";
 import * as Exit from "effect/Exit";
@@ -22,7 +23,7 @@ export const make = Effect.fn(function* <TSchema extends ZeroSchema, TMutators e
 ) {
   const ctx =
     yield* Effect.context<
-      Exclude<Mutators.ExtractMutatorsRequirements<TMutators>, ClientTransaction.ClientTransaction>
+      Exclude<Mutators.ExtractMutatorsRequirements<TMutators>, Context.Service.Identifier<typeof transaction>>
     >();
 
   function unwrapMutator<E>(mutator: Mutators.AnyMutator<Mutators.ExtractMutatorsRequirements<TMutators>, E>) {

--- a/src/internal/server-synchronization-context.ts
+++ b/src/internal/server-synchronization-context.ts
@@ -62,4 +62,3 @@ export const finalize = <A, E, R>(effect: Effect.Effect<A, E, R>) =>
       ),
     );
   });
-

--- a/src/internal/server.test.ts
+++ b/src/internal/server.test.ts
@@ -1,5 +1,4 @@
 import { describe, it } from "@effect/vitest";
-import { assertExitFailure } from "@effect/vitest/utils";
 import * as Cause from "effect/Cause";
 import * as Effect from "effect/Effect";
 import * as Exit from "effect/Exit";
@@ -9,13 +8,17 @@ import * as ServerSynchronizationContext from "./server-synchronization-context.
 describe("ServerSynchronizationContext", () => {
   it.effect(
     "finalize should return NoTransactionError when called without guard",
-    Effect.fn(function* () {
+    Effect.fn(function* ({ expect }) {
       const result = yield* Effect.void.pipe(
         ServerSynchronizationContext.finalize,
         Effect.provide(ServerSynchronizationContext.layer),
         Effect.exit,
       );
-      assertExitFailure(result, Cause.fail(new NoTransactionError()));
+      if (Exit.isFailure(result)) {
+        expect(Cause.squash(result.cause)).toBeInstanceOf(NoTransactionError);
+      } else {
+        expect.fail("Expected failure");
+      }
     }),
   );
 

--- a/src/server-transaction.ts
+++ b/src/server-transaction.ts
@@ -44,29 +44,19 @@ type ServerTransactionService<
   `${Id}/ServerTransactionContext`,
   ServerTransactionContextShape<TSchema, TTransaction>
 > & {
-  readonly usePromise: <A>(
-    fn: (
-      transaction: ZeroServerTransaction<TSchema, TTransaction>,
-      options: { readonly signal: AbortSignal },
-    ) => PromiseLike<A>,
-  ) => Effect.Effect<A, ServerTransactionError, ServerTransactionContextIdentifier<Id, TSchema, TTransaction>>;
-  readonly execute: <A, E, R>(
-    effect: Effect.Effect<A, E, R>,
-  ) => Effect.Effect<
-    A,
-    | E
-    | MultipleTransactionsError
-    | OutOfOrderMutationError
-    | MutationAlreadyProcessedError
-    | UpdateClientMutationIdError
-    | ZeroDatabaseError,
-    | ServerSynchronizationContext.ServerSynchronizationContext
-    | ServerTransactionInput
-    | Exclude<
-        R,
-        Context.Service.Identifier<TClientTransaction> | ServerTransactionContextIdentifier<Id, TSchema, TTransaction>
-      >
-  >;
+  readonly database: ZQLDatabase<TSchema, TTransaction>;
+  readonly clientTransaction: TClientTransaction;
+};
+
+type AnyServerTransaction<
+  TIdentifier,
+  TSchema extends ZeroSchema,
+  TTransaction,
+  TClientIdentifier,
+  TClientTransaction extends Context.Key<TClientIdentifier, ZeroTransaction<TSchema>>,
+> = Context.Service<TIdentifier, ServerTransactionContextShape<TSchema, TTransaction>> & {
+  readonly database: ZQLDatabase<TSchema, TTransaction>;
+  readonly clientTransaction: TClientTransaction;
 };
 
 export const make = <
@@ -83,67 +73,52 @@ export const make = <
     ServerTransactionContext,
     ServerTransactionContextShape<TSchema, TTransaction>
   >()(`${id}/ServerTransactionContext` as const) {
-    static usePromise<A>(
-      fn: (
-        transaction: ZeroServerTransaction<TSchema, TTransaction>,
-        options: { readonly signal: AbortSignal },
-      ) => PromiseLike<A>,
-    ) {
-      return Effect.gen(function* () {
-        const ctx = yield* ServerTransactionContext;
-        return yield* Effect.tryPromise({
-          try: (signal) => fn(ctx.transaction, { signal }),
-          catch: (error) => new ServerTransactionError({ cause: Cause.fail(error) }),
-        });
-      });
-    }
-
-    static readonly execute = Effect.fn(function* <A, E, R>(effect: Effect.Effect<A, E, R>) {
-      const ctx = yield* Effect.context<
-        ServerTransactionInput | Exclude<R, Context.Service.Identifier<TClientTransaction> | ServerTransactionContext>
-      >();
-      const result = yield* Deferred.make<A, E | Effect.Error<typeof checkAndIncrementLastMutationId>>();
-
-      const transactionInput = yield* ServerTransactionInput;
-      yield* Effect.tryPromise({
-        try: (signal) =>
-          database.transaction(async (transaction, transactionHooks) => {
-            const exit = await Effect.flatMap(checkAndIncrementLastMutationId, () => effect).pipe(
-              Effect.provide([
-                Layer.succeed(ServerTransactionContext, { transaction, transactionHooks }),
-                Layer.succeed(clientTransaction, transaction),
-              ]),
-              (effect) => Effect.runPromiseExitWith(ctx)(effect, { signal }),
-            );
-            Deferred.doneUnsafe(result, exit);
-            if (Exit.isFailure(exit)) {
-              // This error's purpose is to differentiate between "external" errors
-              // that originate from the user-defined mutator code and "internal" errors
-              // that originate from our own code and the Zero API.
-              // Both types are caught in the "catch" block below, but at this point we only need to handle
-              // the "internal" errors wrapping them in a `ZeroDatabaseError`, because "external" errors
-              // are already covered by passing the Exit result to the Deferred, which is why
-              // we have the ServerTransactionUserError silenced below in the pipe.
-              throw new ServerTransactionUserError();
-            }
-            return exit.value;
-          }, transactionInput),
-        catch: (error) => {
-          if (ServerTransactionUserError.is(error)) {
-            return error;
-          }
-          // This is for errors that occur when calling `database.transaction` despite the provided `effect` succeeding.
-          // This can be caused by e.g. the database connection timing out or other database-related issues.
-          return new ZeroDatabaseError({ cause: Cause.fail(error) });
-        },
-      }).pipe(Effect.catchTag("ServerTransactionUserError", () => Effect.void));
-
-      return yield* Deferred.await(result);
-    }, ServerSynchronizationContext.guard);
+    static readonly database = database;
+    static readonly clientTransaction = clientTransaction;
   }
 
+  return ServerTransactionContext;
+};
+
+export const use = <TIdentifier, TSchema extends ZeroSchema, TTransaction, A>(
+  serverTransaction: Context.Service<TIdentifier, ServerTransactionContextShape<TSchema, TTransaction>>,
+  fn: (
+    transaction: ZeroServerTransaction<TSchema, TTransaction>,
+    options: { readonly signal: AbortSignal },
+  ) => PromiseLike<A>,
+): Effect.Effect<A, ServerTransactionError, TIdentifier> =>
+  Effect.gen(function* () {
+    const ctx = yield* serverTransaction;
+    return yield* Effect.tryPromise({
+      try: (signal) => fn(ctx.transaction, { signal }),
+      catch: (error) => new ServerTransactionError({ cause: Cause.fail(error) }),
+    });
+  });
+
+export const execute = <
+  TIdentifier,
+  TSchema extends ZeroSchema,
+  TTransaction,
+  TClientIdentifier,
+  TClientTransaction extends Context.Key<TClientIdentifier, ZeroTransaction<TSchema>>,
+>(
+  serverTransaction: AnyServerTransaction<TIdentifier, TSchema, TTransaction, TClientIdentifier, TClientTransaction>,
+): (<A, E, R>(
+  effect: Effect.Effect<A, E, R>,
+) => Effect.Effect<
+  A,
+  | E
+  | MultipleTransactionsError
+  | OutOfOrderMutationError
+  | MutationAlreadyProcessedError
+  | UpdateClientMutationIdError
+  | ZeroDatabaseError,
+  | ServerSynchronizationContext.ServerSynchronizationContext
+  | ServerTransactionInput
+  | Exclude<R, TClientIdentifier | TIdentifier>
+>) => {
   const checkAndIncrementLastMutationId = Effect.gen(function* () {
-    const { transactionHooks } = yield* ServerTransactionContext;
+    const { transactionHooks } = yield* serverTransaction;
     const { clientID, mutationID: receivedMutationID } = yield* ServerTransactionInput;
 
     const { lastMutationID } = yield* Effect.tryPromise({
@@ -167,7 +142,46 @@ export const make = <
     }
   });
 
-  return ServerTransactionContext;
+  return Effect.fn(function* <A, E, R>(effect: Effect.Effect<A, E, R>) {
+    const ctx = yield* Effect.context<ServerTransactionInput | Exclude<R, TClientIdentifier | TIdentifier>>();
+    const result = yield* Deferred.make<A, E | Effect.Error<typeof checkAndIncrementLastMutationId>>();
+
+    const transactionInput = yield* ServerTransactionInput;
+    yield* Effect.tryPromise({
+      try: (signal) =>
+        serverTransaction.database.transaction(async (transaction, transactionHooks) => {
+          const exit = await Effect.flatMap(checkAndIncrementLastMutationId, () => effect).pipe(
+            Effect.provide([
+              Layer.succeed(serverTransaction, { transaction, transactionHooks }),
+              Layer.succeed(serverTransaction.clientTransaction, transaction),
+            ]),
+            (effect) => Effect.runPromiseExitWith(ctx)(effect, { signal }),
+          );
+          Deferred.doneUnsafe(result, exit);
+          if (Exit.isFailure(exit)) {
+            // This error's purpose is to differentiate between "external" errors
+            // that originate from the user-defined mutator code and "internal" errors
+            // that originate from our own code and the Zero API.
+            // Both types are caught in the "catch" block below, but at this point we only need to handle
+            // the "internal" errors wrapping them in a `ZeroDatabaseError`, because "external" errors
+            // are already covered by passing the Exit result to the Deferred, which is why
+            // we have the ServerTransactionUserError silenced below in the pipe.
+            throw new ServerTransactionUserError();
+          }
+          return exit.value;
+        }, transactionInput),
+      catch: (error) => {
+        if (ServerTransactionUserError.is(error)) {
+          return error;
+        }
+        // This is for errors that occur when calling `database.transaction` despite the provided `effect` succeeding.
+        // This can be caused by e.g. the database connection timing out or other database-related issues.
+        return new ZeroDatabaseError({ cause: Cause.fail(error) });
+      },
+    }).pipe(Effect.catchTag("ServerTransactionUserError", () => Effect.void));
+
+    return yield* Deferred.await(result);
+  }, ServerSynchronizationContext.guard);
 };
 
 class ServerTransactionError extends Data.TaggedError("ServerTransactionError")<{

--- a/src/server-transaction.ts
+++ b/src/server-transaction.ts
@@ -25,6 +25,7 @@ import { prefixId } from "./internal/utils.js";
 
 // Updated to: https://github.com/rocicorp/mono/blob/3082c9fa061891067b4bd7dc9fe74f798270d8d7/packages/zero-server/src/push-processor.ts
 
+// Self-type anchor for the factory-built Tag. See client-transaction.ts for the full rationale.
 export interface ServerTransactionContext {
   readonly _tag: unique symbol;
 }

--- a/src/server-transaction.ts
+++ b/src/server-transaction.ts
@@ -12,8 +12,6 @@ import * as Effect from "effect/Effect";
 import * as Exit from "effect/Exit";
 import * as Layer from "effect/Layer";
 import * as Predicate from "effect/Predicate";
-import type * as Types from "effect/Types";
-import type * as ClientTransaction from "./client-transaction.js";
 import {
   type MultipleTransactionsError,
   MutationAlreadyProcessedError,
@@ -25,28 +23,33 @@ import { prefixId } from "./internal/utils.js";
 
 // Updated to: https://github.com/rocicorp/mono/blob/3082c9fa061891067b4bd7dc9fe74f798270d8d7/packages/zero-server/src/push-processor.ts
 
-// Self-type anchor for the factory-built Tag. See client-transaction.ts for the full rationale.
-export interface ServerTransactionContext {
-  readonly _tag: unique symbol;
-}
-
 type ServerTransactionContextShape<TSchema extends ZeroSchema, TTransaction> = {
   transaction: ZeroServerTransaction<TSchema, TTransaction>;
   transactionHooks: TransactionProviderHooks;
 };
 
-export interface ServerTransactionTag<Id extends string, TSchema extends ZeroSchema, TTransaction>
-  extends Context.ServiceClass<
-    ServerTransactionContext,
-    `${Id}/ServerTransactionContext`,
-    ServerTransactionContextShape<TSchema, TTransaction>
-  > {
+type ServerTransactionContextIdentifier<
+  Id extends string,
+  TSchema extends ZeroSchema,
+  TTransaction,
+> = Context.ServiceClass.Shape<`${Id}/ServerTransactionContext`, ServerTransactionContextShape<TSchema, TTransaction>>;
+
+type ServerTransactionService<
+  Id extends string,
+  TSchema extends ZeroSchema,
+  TTransaction,
+  TClientTransaction extends Context.Key<unknown, ZeroTransaction<TSchema>>,
+> = Context.ServiceClass<
+  ServerTransactionContextIdentifier<Id, TSchema, TTransaction>,
+  `${Id}/ServerTransactionContext`,
+  ServerTransactionContextShape<TSchema, TTransaction>
+> & {
   readonly usePromise: <A>(
     fn: (
       transaction: ZeroServerTransaction<TSchema, TTransaction>,
       options: { readonly signal: AbortSignal },
     ) => PromiseLike<A>,
-  ) => Effect.Effect<A, ServerTransactionError, ServerTransactionContext>;
+  ) => Effect.Effect<A, ServerTransactionError, ServerTransactionContextIdentifier<Id, TSchema, TTransaction>>;
   readonly execute: <A, E, R>(
     effect: Effect.Effect<A, E, R>,
   ) => Effect.Effect<
@@ -59,83 +62,88 @@ export interface ServerTransactionTag<Id extends string, TSchema extends ZeroSch
     | ZeroDatabaseError,
     | ServerSynchronizationContext.ServerSynchronizationContext
     | ServerTransactionInput
-    | Exclude<R, ClientTransaction.ClientTransaction | ServerTransactionContext>
+    | Exclude<
+        R,
+        Context.Service.Identifier<TClientTransaction> | ServerTransactionContextIdentifier<Id, TSchema, TTransaction>
+      >
   >;
-}
+};
 
-export const make = <const Id extends string, TSchema extends ZeroSchema, TTransaction>(
+export const make = <
+  const Id extends string,
+  TSchema extends ZeroSchema,
+  TTransaction,
+  TClientTransaction extends Context.Key<unknown, ZeroTransaction<TSchema>>,
+>(
   id: Id,
   database: ZQLDatabase<TSchema, TTransaction>,
-  clientTransaction: Context.Key<ClientTransaction.ClientTransaction, ZeroTransaction<TSchema>>,
-): ServerTransactionTag<Id, TSchema, TTransaction> => {
-  class Tag extends Context.Service<ServerTransactionContext, ServerTransactionContextShape<TSchema, TTransaction>>()(
-    `${id}/ServerTransactionContext` as const,
-  ) {}
-
-  // Mutate-via-Mutable-cast pattern from effect-smol/src/Layer/LayerMap.ts:307-374. Attaches
-  // `usePromise` and `execute` directly on the Service-derived class. Promise-based `usePromise`
-  // is named distinctly so it doesn't shadow the inherited `Context.Service.use`.
-  const Tag_ = Tag as unknown as Types.Mutable<ServerTransactionTag<Id, TSchema, TTransaction>>;
-
-  Tag_.usePromise = <A>(
-    fn: (
-      transaction: ZeroServerTransaction<TSchema, TTransaction>,
-      options: { readonly signal: AbortSignal },
-    ) => PromiseLike<A>,
-  ) =>
-    Effect.gen(function* () {
-      const ctx = yield* Tag;
-      return yield* Effect.tryPromise({
-        try: (signal) => fn(ctx.transaction, { signal }),
-        catch: (error) => new ServerTransactionError({ cause: Cause.fail(error) }),
+  clientTransaction: TClientTransaction,
+): ServerTransactionService<Id, TSchema, TTransaction, TClientTransaction> => {
+  class ServerTransactionContext extends Context.Service<
+    ServerTransactionContext,
+    ServerTransactionContextShape<TSchema, TTransaction>
+  >()(`${id}/ServerTransactionContext` as const) {
+    static usePromise<A>(
+      fn: (
+        transaction: ZeroServerTransaction<TSchema, TTransaction>,
+        options: { readonly signal: AbortSignal },
+      ) => PromiseLike<A>,
+    ) {
+      return Effect.gen(function* () {
+        const ctx = yield* ServerTransactionContext;
+        return yield* Effect.tryPromise({
+          try: (signal) => fn(ctx.transaction, { signal }),
+          catch: (error) => new ServerTransactionError({ cause: Cause.fail(error) }),
+        });
       });
-    });
+    }
 
-  Tag_.execute = Effect.fn(function* <A, E, R>(effect: Effect.Effect<A, E, R>) {
-    const ctx = yield* Effect.context<
-      ServerTransactionInput | Exclude<R, ClientTransaction.ClientTransaction | ServerTransactionContext>
-    >();
-    const result = yield* Deferred.make<A, E | Effect.Error<typeof checkAndIncrementLastMutationId>>();
+    static readonly execute = Effect.fn(function* <A, E, R>(effect: Effect.Effect<A, E, R>) {
+      const ctx = yield* Effect.context<
+        ServerTransactionInput | Exclude<R, Context.Service.Identifier<TClientTransaction> | ServerTransactionContext>
+      >();
+      const result = yield* Deferred.make<A, E | Effect.Error<typeof checkAndIncrementLastMutationId>>();
 
-    const transactionInput = yield* ServerTransactionInput;
-    yield* Effect.tryPromise({
-      try: (signal) =>
-        database.transaction(async (transaction, transactionHooks) => {
-          const exit = await Effect.flatMap(checkAndIncrementLastMutationId, () => effect).pipe(
-            Effect.provide([
-              Layer.succeed(Tag, { transaction, transactionHooks }),
-              Layer.succeed(clientTransaction, transaction),
-            ]),
-            (effect) => Effect.runPromiseExitWith(ctx)(effect, { signal }),
-          );
-          Deferred.doneUnsafe(result, exit);
-          if (Exit.isFailure(exit)) {
-            // This error's purpose is to differentiate between "external" errors
-            // that originate from the user-defined mutator code and "internal" errors
-            // that originate from our own code and the Zero API.
-            // Both types are caught in the "catch" block below, but at this point we only need to handle
-            // the "internal" errors wrapping them in a `ZeroDatabaseError`, because "external" errors
-            // are already covered by passing the Exit result to the Deferred, which is why
-            // we have the ServerTransactionUserError silenced below in the pipe.
-            throw new ServerTransactionUserError();
+      const transactionInput = yield* ServerTransactionInput;
+      yield* Effect.tryPromise({
+        try: (signal) =>
+          database.transaction(async (transaction, transactionHooks) => {
+            const exit = await Effect.flatMap(checkAndIncrementLastMutationId, () => effect).pipe(
+              Effect.provide([
+                Layer.succeed(ServerTransactionContext, { transaction, transactionHooks }),
+                Layer.succeed(clientTransaction, transaction),
+              ]),
+              (effect) => Effect.runPromiseExitWith(ctx)(effect, { signal }),
+            );
+            Deferred.doneUnsafe(result, exit);
+            if (Exit.isFailure(exit)) {
+              // This error's purpose is to differentiate between "external" errors
+              // that originate from the user-defined mutator code and "internal" errors
+              // that originate from our own code and the Zero API.
+              // Both types are caught in the "catch" block below, but at this point we only need to handle
+              // the "internal" errors wrapping them in a `ZeroDatabaseError`, because "external" errors
+              // are already covered by passing the Exit result to the Deferred, which is why
+              // we have the ServerTransactionUserError silenced below in the pipe.
+              throw new ServerTransactionUserError();
+            }
+            return exit.value;
+          }, transactionInput),
+        catch: (error) => {
+          if (ServerTransactionUserError.is(error)) {
+            return error;
           }
-          return exit.value;
-        }, transactionInput),
-      catch: (error) => {
-        if (ServerTransactionUserError.is(error)) {
-          return error;
-        }
-        // This is for errors that occur when calling `database.transaction` despite the provided `effect` succeeding.
-        // This can be caused by e.g. the database connection timing out or other database-related issues.
-        return new ZeroDatabaseError({ cause: Cause.fail(error) });
-      },
-    }).pipe(Effect.catchTag("ServerTransactionUserError", () => Effect.void));
+          // This is for errors that occur when calling `database.transaction` despite the provided `effect` succeeding.
+          // This can be caused by e.g. the database connection timing out or other database-related issues.
+          return new ZeroDatabaseError({ cause: Cause.fail(error) });
+        },
+      }).pipe(Effect.catchTag("ServerTransactionUserError", () => Effect.void));
 
-    return yield* Deferred.await(result);
-  }, ServerSynchronizationContext.guard);
+      return yield* Deferred.await(result);
+    }, ServerSynchronizationContext.guard);
+  }
 
   const checkAndIncrementLastMutationId = Effect.gen(function* () {
-    const { transactionHooks } = yield* Tag;
+    const { transactionHooks } = yield* ServerTransactionContext;
     const { clientID, mutationID: receivedMutationID } = yield* ServerTransactionInput;
 
     const { lastMutationID } = yield* Effect.tryPromise({
@@ -159,7 +167,7 @@ export const make = <const Id extends string, TSchema extends ZeroSchema, TTrans
     }
   });
 
-  return Tag_ as ServerTransactionTag<Id, TSchema, TTransaction>;
+  return ServerTransactionContext;
 };
 
 class ServerTransactionError extends Data.TaggedError("ServerTransactionError")<{

--- a/src/server-transaction.ts
+++ b/src/server-transaction.ts
@@ -12,8 +12,14 @@ import * as Effect from "effect/Effect";
 import * as Exit from "effect/Exit";
 import * as Layer from "effect/Layer";
 import * as Predicate from "effect/Predicate";
+import type * as Types from "effect/Types";
 import type * as ClientTransaction from "./client-transaction.js";
-import { MutationAlreadyProcessedError, OutOfOrderMutationError, ServerTransactionInput } from "./internal/server.js";
+import {
+  type MultipleTransactionsError,
+  MutationAlreadyProcessedError,
+  OutOfOrderMutationError,
+  ServerTransactionInput,
+} from "./internal/server.js";
 import * as ServerSynchronizationContext from "./internal/server-synchronization-context.js";
 import { prefixId } from "./internal/utils.js";
 
@@ -23,30 +29,68 @@ export interface ServerTransactionContext {
   readonly _tag: unique symbol;
 }
 
+type ServerTransactionContextShape<TSchema extends ZeroSchema, TTransaction> = {
+  transaction: ZeroServerTransaction<TSchema, TTransaction>;
+  transactionHooks: TransactionProviderHooks;
+};
+
+export interface ServerTransactionTag<Id extends string, TSchema extends ZeroSchema, TTransaction>
+  extends Context.ServiceClass<
+    ServerTransactionContext,
+    `${Id}/ServerTransactionContext`,
+    ServerTransactionContextShape<TSchema, TTransaction>
+  > {
+  readonly usePromise: <A>(
+    fn: (
+      transaction: ZeroServerTransaction<TSchema, TTransaction>,
+      options: { readonly signal: AbortSignal },
+    ) => PromiseLike<A>,
+  ) => Effect.Effect<A, ServerTransactionError, ServerTransactionContext>;
+  readonly execute: <A, E, R>(
+    effect: Effect.Effect<A, E, R>,
+  ) => Effect.Effect<
+    A,
+    | E
+    | MultipleTransactionsError
+    | OutOfOrderMutationError
+    | MutationAlreadyProcessedError
+    | UpdateClientMutationIdError
+    | ZeroDatabaseError,
+    | ServerSynchronizationContext.ServerSynchronizationContext
+    | ServerTransactionInput
+    | Exclude<R, ClientTransaction.ClientTransaction | ServerTransactionContext>
+  >;
+}
+
 export const make = <const Id extends string, TSchema extends ZeroSchema, TTransaction>(
   id: Id,
   database: ZQLDatabase<TSchema, TTransaction>,
-  clientTransaction: Context.TagClass<ClientTransaction.ClientTransaction, string, ZeroTransaction<TSchema>>,
-) => {
-  const ServerTransactionContext = Context.Tag(`${id}/ServerTransactionContext` as const)<
-    ServerTransactionContext,
-    { transaction: ZeroServerTransaction<TSchema, TTransaction>; transactionHooks: TransactionProviderHooks }
-  >();
+  clientTransaction: Context.Key<ClientTransaction.ClientTransaction, ZeroTransaction<TSchema>>,
+): ServerTransactionTag<Id, TSchema, TTransaction> => {
+  class Tag extends Context.Service<ServerTransactionContext, ServerTransactionContextShape<TSchema, TTransaction>>()(
+    `${id}/ServerTransactionContext` as const,
+  ) {}
 
-  const use = <A>(
+  // Mutate-via-Mutable-cast pattern from effect-smol/src/Layer/LayerMap.ts:307-374. Attaches
+  // `usePromise` and `execute` directly on the Service-derived class. Promise-based `usePromise`
+  // is named distinctly so it doesn't shadow the inherited `Context.Service.use`.
+  const Tag_ = Tag as unknown as Types.Mutable<ServerTransactionTag<Id, TSchema, TTransaction>>;
+
+  Tag_.usePromise = <A>(
     fn: (
       transaction: ZeroServerTransaction<TSchema, TTransaction>,
       options: { readonly signal: AbortSignal },
     ) => PromiseLike<A>,
   ) =>
-    Effect.flatMap(ServerTransactionContext, (ctx) =>
-      Effect.tryPromise({
+    Effect.gen(function* () {
+      const ctx = yield* Tag;
+      return yield* Effect.tryPromise({
         try: (signal) => fn(ctx.transaction, { signal }),
         catch: (error) => new ServerTransactionError({ cause: Cause.fail(error) }),
-      }),
-    );
+      });
+    });
 
-  const execute = Effect.fn(function* <A, E, R>(effect: Effect.Effect<A, E, R>) {
+  Tag_.execute = Effect.fn(function* <A, E, R>(effect: Effect.Effect<A, E, R>) {
     const ctx = yield* Effect.context<
       ServerTransactionInput | Exclude<R, ClientTransaction.ClientTransaction | ServerTransactionContext>
     >();
@@ -58,7 +102,7 @@ export const make = <const Id extends string, TSchema extends ZeroSchema, TTrans
         database.transaction(async (transaction, transactionHooks) => {
           const exit = await Effect.flatMap(checkAndIncrementLastMutationId, () => effect).pipe(
             Effect.provide([
-              Layer.succeed(ServerTransactionContext, { transaction, transactionHooks }),
+              Layer.succeed(Tag, { transaction, transactionHooks }),
               Layer.succeed(clientTransaction, transaction),
             ]),
             (effect) => Effect.runPromiseExitWith(ctx)(effect, { signal }),
@@ -90,7 +134,7 @@ export const make = <const Id extends string, TSchema extends ZeroSchema, TTrans
   }, ServerSynchronizationContext.guard);
 
   const checkAndIncrementLastMutationId = Effect.gen(function* () {
-    const { transactionHooks } = yield* ServerTransactionContext;
+    const { transactionHooks } = yield* Tag;
     const { clientID, mutationID: receivedMutationID } = yield* ServerTransactionInput;
 
     const { lastMutationID } = yield* Effect.tryPromise({
@@ -114,7 +158,7 @@ export const make = <const Id extends string, TSchema extends ZeroSchema, TTrans
     }
   });
 
-  return Object.assign(ServerTransactionContext, { use, execute });
+  return Tag_ as ServerTransactionTag<Id, TSchema, TTransaction>;
 };
 
 class ServerTransactionError extends Data.TaggedError("ServerTransactionError")<{

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,7 +1,8 @@
-import type { ReadonlyJSONValue, Schema as ZeroSchema } from "@rocicorp/zero";
+import type { ReadonlyJSONValue, Schema as ZeroSchema, Transaction as ZeroTransaction } from "@rocicorp/zero";
 import { handleQueryRequest } from "@rocicorp/zero/server";
 import * as Arr from "effect/Array";
 import * as Cause from "effect/Cause";
+import type * as Context from "effect/Context";
 import * as Data from "effect/Data";
 import * as Effect from "effect/Effect";
 import * as Exit from "effect/Exit";
@@ -26,17 +27,21 @@ import type { TransformRequestMessage } from "./types/queries.js";
 // https://github.com/rocicorp/mono/blob/3082c9fa061891067b4bd7dc9fe74f798270d8d7/packages/zero-server/src/push-processor.ts
 // https://github.com/rocicorp/mono/blob/3082c9fa061891067b4bd7dc9fe74f798270d8d7/packages/zero-server/src/process-mutations.ts
 
-type ServerTransactionContext<TSchema extends ZeroSchema, TTransaction> = Omit<
-  ReturnType<typeof ServerTransaction.make<string, TSchema, TTransaction>>,
-  "use"
->;
-
-export const processPush = Effect.fn(function* <
+type ServerTransactionContext<
+  TId extends string,
   TSchema extends ZeroSchema,
   TTransaction,
+  TClientTransaction extends Context.Key<unknown, ZeroTransaction<TSchema>>,
+> = Omit<ReturnType<typeof ServerTransaction.make<TId, TSchema, TTransaction, TClientTransaction>>, "use">;
+
+export const processPush = Effect.fn(function* <
+  TId extends string,
+  TSchema extends ZeroSchema,
+  TTransaction,
+  TClientTransaction extends Context.Key<unknown, ZeroTransaction<TSchema>>,
   TMutators extends Mutators.AnyMutators,
 >(
-  transaction: ServerTransactionContext<TSchema, TTransaction>,
+  transaction: ServerTransactionContext<TId, TSchema, TTransaction, TClientTransaction>,
   mutators: TMutators,
   params: Types.PushParams,
   request: Types.PushBody,
@@ -118,10 +123,12 @@ const processMutation = Effect.fn(function* <R>(mutators: Mutators.AnyMutators<R
   );
 });
 
-const processMutationError = Effect.fn(function* <TSchema extends ZeroSchema, TTransaction>(
-  transaction: ServerTransactionContext<TSchema, TTransaction>,
-  e: unknown,
-) {
+const processMutationError = Effect.fn(function* <
+  TId extends string,
+  TSchema extends ZeroSchema,
+  TTransaction,
+  TClientTransaction extends Context.Key<unknown, ZeroTransaction<TSchema>>,
+>(transaction: ServerTransactionContext<TId, TSchema, TTransaction, TClientTransaction>, e: unknown) {
   const { clientID, mutationID } = yield* ServerTransactionInput;
 
   yield* Effect.logError(`Unexpected error processing mutation ${mutationID} for client ${clientID}`, Cause.fail(e));

--- a/src/server.ts
+++ b/src/server.ts
@@ -19,7 +19,7 @@ import * as ServerSynchronizationContext from "./internal/server-synchronization
 import { prefixId } from "./internal/utils.js";
 import * as Mutators from "./mutators.js";
 import { type MakeQueryResult, QueryNameSymbol, RunQuerySymbol } from "./query.js";
-import type * as ServerTransaction from "./server-transaction.js";
+import * as ServerTransaction from "./server-transaction.js";
 import * as Types from "./types/push.js";
 import type { TransformRequestMessage } from "./types/queries.js";
 
@@ -32,7 +32,7 @@ type ServerTransactionContext<
   TSchema extends ZeroSchema,
   TTransaction,
   TClientTransaction extends Context.Key<unknown, ZeroTransaction<TSchema>>,
-> = Omit<ReturnType<typeof ServerTransaction.make<TId, TSchema, TTransaction, TClientTransaction>>, "use">;
+> = ReturnType<typeof ServerTransaction.make<TId, TSchema, TTransaction, TClientTransaction>>;
 
 export const processPush = Effect.fn(function* <
   TId extends string,
@@ -143,17 +143,13 @@ const processMutationError = Effect.fn(function* <
     details: errorMessage,
   } satisfies Types.AppError;
 
-  yield* transaction
-    .execute(
-      Effect.gen(function* () {
-        const { transactionHooks } = yield* transaction;
-        return yield* Effect.tryPromise({
-          try: () => transactionHooks.writeMutationResult({ id: { id: mutationID, clientID }, result: appError }),
-          catch: (error) => new WriteMutationResultError({ cause: Cause.fail(error) }),
-        });
-      }),
-    )
-    .pipe(Effect.catchCause(Effect.logError));
+  yield* Effect.gen(function* () {
+    const { transactionHooks } = yield* transaction;
+    return yield* Effect.tryPromise({
+      try: () => transactionHooks.writeMutationResult({ id: { id: mutationID, clientID }, result: appError }),
+      catch: (error) => new WriteMutationResultError({ cause: Cause.fail(error) }),
+    });
+  }).pipe(ServerTransaction.execute(transaction), Effect.catchCause(Effect.logError));
 
   yield* Effect.logWarning(`Mutation ${mutationID} for client ${clientID} was retried after an error: ${e}`);
 

--- a/src/types.test.ts
+++ b/src/types.test.ts
@@ -56,7 +56,7 @@ describe("Type tests", () => {
       const mutators = Mutators.make(mutatorSchema, {
         messages: {
           create: (msg) =>
-            clientTransaction.use(async () => {
+            clientTransaction.usePromise(async () => {
               // Use msg to verify type
               const _id: string = msg.id;
               const _body: string = msg.body;
@@ -108,17 +108,17 @@ describe("Type tests", () => {
         todo: {
           // Using arrow function with explicit type for best inference
           create: (args: { id: string; title: string }) =>
-            clientTransaction.use(async () => {
+            clientTransaction.usePromise(async () => {
               const _id: string = args.id;
               const _title: string = args.title;
             }),
           // Using Effect.fn with explicit type annotation
-          toggle: Effect.fn(function* (args: { id: string; done: boolean }) {
-            yield* clientTransaction.use(async () => {});
+          toggle: Effect.fn(function* (_args: { id: string; done: boolean }) {
+            yield* clientTransaction.usePromise(async () => {});
           }),
           // Using Effect.fn with no args (void schema)
           delete: Effect.fn(function* () {
-            yield* clientTransaction.use(async () => {});
+            yield* clientTransaction.usePromise(async () => {});
           }),
         },
       });

--- a/src/types.test.ts
+++ b/src/types.test.ts
@@ -56,7 +56,7 @@ describe("Type tests", () => {
       const mutators = Mutators.make(mutatorSchema, {
         messages: {
           create: (msg) =>
-            clientTransaction.usePromise(async () => {
+            ClientTransaction.use(clientTransaction, async () => {
               // Use msg to verify type
               const _id: string = msg.id;
               const _body: string = msg.body;
@@ -108,17 +108,17 @@ describe("Type tests", () => {
         todo: {
           // Using arrow function with explicit type for best inference
           create: (args: { id: string; title: string }) =>
-            clientTransaction.usePromise(async () => {
+            ClientTransaction.use(clientTransaction, async () => {
               const _id: string = args.id;
               const _title: string = args.title;
             }),
           // Using Effect.fn with explicit type annotation
           toggle: Effect.fn(function* (_args: { id: string; done: boolean }) {
-            yield* clientTransaction.usePromise(async () => {});
+            yield* ClientTransaction.use(clientTransaction, async () => {});
           }),
           // Using Effect.fn with no args (void schema)
           delete: Effect.fn(function* () {
-            yield* clientTransaction.usePromise(async () => {});
+            yield* ClientTransaction.use(clientTransaction, async () => {});
           }),
         },
       });

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -78,14 +78,14 @@ const serverTransaction = ZfxServerTransaction.make("ServerTransaction", databas
 
 const transformArgsClient = vi.fn(
   Effect.fn(function* (a) {
-    yield* clientTransaction.use(async () => {});
+    yield* ZfxClientTransaction.use(clientTransaction, async () => {});
     return a;
   }),
 );
 
 const transformArgsServer = vi.fn(
   Effect.fn(function* (a) {
-    yield* serverTransaction.use(async () => {});
+    yield* ZfxServerTransaction.use(serverTransaction, async () => {});
     return a;
   }),
 );
@@ -93,16 +93,16 @@ const transformArgsServer = vi.fn(
 const clientMutators = ZfxMutators.make(mutatorSchema, {
   messages: {
     create: (msg) =>
-      clientTransaction.use(async (tx) => {
+      ZfxClientTransaction.use(clientTransaction, async (tx) => {
         await tx.mutate.messages.insert(msg);
       }),
     updateMessage: Effect.fn(function* (msg: { id: string; body: string }) {
-      yield* clientTransaction.use(async (tx) => {
+      yield* ZfxClientTransaction.use(clientTransaction, async (tx) => {
         await tx.mutate.messages.update(msg);
       });
     }),
     deleteAll: Effect.fn(function* () {
-      yield* clientTransaction.use(async (_tx) => {});
+      yield* ZfxClientTransaction.use(clientTransaction, async (_tx) => {});
     }),
   },
   /** biome-ignore lint/correctness/noUnusedFunctionParameters: required for test */
@@ -127,35 +127,31 @@ const clientMutators = ZfxMutators.make(mutatorSchema, {
 
 const serverMutators = ZfxMutators.make(mutatorSchema, {
   messages: {
-    create: (msg) => clientMutators.messages.create(msg).pipe(serverTransaction.execute),
+    create: (msg) => clientMutators.messages.create(msg).pipe(ZfxServerTransaction.execute(serverTransaction)),
     updateMessage: Effect.fn(function* (msg: { id: string; body: string }) {
-      yield* clientMutators.messages.updateMessage(msg).pipe(serverTransaction.execute);
+      yield* clientMutators.messages.updateMessage(msg).pipe(ZfxServerTransaction.execute(serverTransaction));
     }),
     deleteAll: Effect.fn(function* () {
-      yield* clientMutators.messages.deleteAll().pipe(serverTransaction.execute);
+      yield* clientMutators.messages.deleteAll().pipe(ZfxServerTransaction.execute(serverTransaction));
     }),
   },
   optionalVoidArg: Effect.fn(function* () {}),
   transformArgs: Effect.fn(function* (a) {
-    return yield* transformArgsServer(a).pipe(serverTransaction.execute);
+    return yield* transformArgsServer(a).pipe(ZfxServerTransaction.execute(serverTransaction));
   }),
   throwsError: Effect.fn(function* () {
     yield* Effect.void;
     throw new Error("error in throwsError");
   }),
   throwsErrorInsideTransaction: Effect.fn(function* () {
-    yield* serverTransaction
-      .use(() => {
-        throw new Error("error in throwsErrorInsideTransaction");
-      })
-      .pipe(serverTransaction.execute);
+    yield* ZfxServerTransaction.use(serverTransaction, () => {
+      throw new Error("error in throwsErrorInsideTransaction");
+    }).pipe(ZfxServerTransaction.execute(serverTransaction));
   }),
   throwsErrorAfterTransaction: Effect.fn(function* () {
-    yield* serverTransaction
-      .use(async (tx) => {
-        await tx.dbTransaction.wrappedTransaction.insert(messages).values({ id: nanoid(), body: "hello world" });
-      })
-      .pipe(serverTransaction.execute);
+    yield* ZfxServerTransaction.use(serverTransaction, async (tx) => {
+      await tx.dbTransaction.wrappedTransaction.insert(messages).values({ id: nanoid(), body: "hello world" });
+    }).pipe(ZfxServerTransaction.execute(serverTransaction));
     throw new Error("error in throwsErrorAfterTransaction");
   }),
   clientThrowsError: Effect.fn(function* () {}),
@@ -163,42 +159,34 @@ const serverMutators = ZfxMutators.make(mutatorSchema, {
     yield* Effect.fail(new Error("error in yieldsError"));
   }),
   yieldsErrorInsideTransaction: Effect.fn(function* () {
-    yield* Effect.fail(new Error("error in yieldsErrorInsideTransaction")).pipe(serverTransaction.execute);
+    yield* Effect.fail(new Error("error in yieldsErrorInsideTransaction")).pipe(
+      ZfxServerTransaction.execute(serverTransaction),
+    );
   }),
   yieldsErrorAfterTransaction: Effect.fn(function* () {
-    yield* serverTransaction
-      .use(async (tx) => {
-        await tx.mutate.messages.insert({ id: nanoid(), body: "hello world" });
-      })
-      .pipe(serverTransaction.execute);
+    yield* ZfxServerTransaction.use(serverTransaction, async (tx) => {
+      await tx.mutate.messages.insert({ id: nanoid(), body: "hello world" });
+    }).pipe(ZfxServerTransaction.execute(serverTransaction));
     yield* Effect.fail(new Error("error in yieldsErrorAfterTransaction"));
   }),
   noTransaction: Effect.fn(function* () {}),
   doubleTransaction: Effect.fn(function* () {
-    yield* serverTransaction
-      .use(async (tx) => {
-        await tx.mutate.messages.insert({ id: nanoid(), body: "hello world" });
-      })
-      .pipe(serverTransaction.execute);
-    yield* serverTransaction
-      .use(async (tx) => {
-        await tx.mutate.messages.insert({ id: nanoid(), body: "hello world" });
-      })
-      .pipe(serverTransaction.execute);
+    yield* ZfxServerTransaction.use(serverTransaction, async (tx) => {
+      await tx.mutate.messages.insert({ id: nanoid(), body: "hello world" });
+    }).pipe(ZfxServerTransaction.execute(serverTransaction));
+    yield* ZfxServerTransaction.use(serverTransaction, async (tx) => {
+      await tx.mutate.messages.insert({ id: nanoid(), body: "hello world" });
+    }).pipe(ZfxServerTransaction.execute(serverTransaction));
   }),
   concurrentTransactions: Effect.fn(function* () {
     yield* Effect.all(
       [
-        serverTransaction
-          .use(async (tx) => {
-            await tx.mutate.messages.insert({ id: nanoid(), body: "hello world" });
-          })
-          .pipe(serverTransaction.execute),
-        serverTransaction
-          .use(async (tx) => {
-            await tx.mutate.messages.insert({ id: nanoid(), body: "hello world" });
-          })
-          .pipe(serverTransaction.execute),
+        ZfxServerTransaction.use(serverTransaction, async (tx) => {
+          await tx.mutate.messages.insert({ id: nanoid(), body: "hello world" });
+        }).pipe(ZfxServerTransaction.execute(serverTransaction)),
+        ZfxServerTransaction.use(serverTransaction, async (tx) => {
+          await tx.mutate.messages.insert({ id: nanoid(), body: "hello world" });
+        }).pipe(ZfxServerTransaction.execute(serverTransaction)),
       ],
       { concurrency: "unbounded" },
     );


### PR DESCRIPTION
## Summary

Round 3a — migrate `src/client-transaction.ts` and `src/server-transaction.ts` to Effect v4 `Context.Service`, using canonical service classes plus module-level helper functions. **Branches off #38 (base PR).**

This now follows the same shape as `server-synchronization-context`: the service is just the service key/configuration, while behavior is exported as top-level module functions and consumed through namespace imports.

## What changed

- Removed the `Types.Mutable` cast / post-class mutation pattern from both transaction factories.
- Removed the exported self-anchor interfaces and exported tag interfaces.
- Factory-local services now use the direct v4 form:

```ts
class ClientTransaction extends Context.Service<ClientTransaction, ZeroTransaction<TSchema>>()(id) {
  static readonly schema = schema;
}
```

- Moved transaction behavior off the service classes:
  - `ClientTransaction.use(clientTransaction, fn)`
  - `ServerTransaction.use(serverTransaction, fn)`
  - `ServerTransaction.execute(serverTransaction)(effect)`
- Renamed the promise helper back from `usePromise` to `use`, because it no longer shadows `Context.Service.use` as a static service member.
- Updated root type tests and the integration test call sites to use namespace-style imports for these helpers.
- Preserved literal service identifiers in `client.ts` / `server.ts` so requirement exclusion continues to remove only the actual transaction services.
- Made the `ServerSynchronizationContext.finalize` test assert the semantic `NoTransactionError` instead of exact `Cause` object equality, which includes stack annotations in Effect v4.

## Why

The previous approach still treated helper methods as part of the service value. Moving helpers to module functions matches the pattern already used for `ServerSynchronizationContext.guard/finalize`, avoids custom service-member collisions entirely, and lets `use` regain the obvious name.

The remaining type aliases describe public declaration boundaries and preserve literal service identifiers; they are not behavior workarounds.

## Verified

- `bun run typecheck`
- `bun run test`
- `bun run build`
- Focused Biome check on changed source files:
  `bunx biome check --error-on-warnings src/client-transaction.ts src/server-transaction.ts src/client.ts src/server.ts src/internal/server.test.ts`
- Rebuilt `tests/` against the generated tarball and confirmed no remaining errors reference the transaction helper API names. Full `tests/test:types` is still blocked by the broader tests migration (for example missing `schema.gen` and unrelated Effect v4 API changes).
