### PR TITLE
Effect v4 r3a step 1: client/server transactions in canonical service shape

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,5 +32,3 @@ report.[0-9]_.[0-9]_.[0-9]_.[0-9]_.json
 
 # Finder (MacOS) folder config
 .DS_Store
-
-.vscode

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,3 @@
+{
+  "recommendations": ["biomejs.biome"]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,36 @@
+{
+  "typescript.tsdk": "node_modules/typescript/lib",
+  "typescript.enablePromptUseWorkspaceTsdk": true,
+  "editor.defaultFormatter": "biomejs.biome",
+  "editor.formatOnSave": true,
+  // define each one individually to override any potential conflicting global settings
+  "[typescript]": {
+    "editor.defaultFormatter": "biomejs.biome"
+  },
+  "[javascript]": {
+    "editor.defaultFormatter": "biomejs.biome"
+  },
+  "[javascriptreact]": {
+    "editor.defaultFormatter": "biomejs.biome"
+  },
+  "[typescriptreact]": {
+    "editor.defaultFormatter": "biomejs.biome"
+  },
+  "[json]": {
+    "editor.defaultFormatter": "biomejs.biome"
+  },
+  "[jsonc]": {
+    "editor.defaultFormatter": "biomejs.biome"
+  },
+  "biome.enabled": true,
+  "editor.codeActionsOnSave": {
+    // Keep fixes opt-in so save stays fast.
+    "source.fixAll.biome": "explicit"
+  },
+  "files.exclude": {
+    "**/.git": false,
+    "**/.DS_Store": false,
+    "**/bun.lockb": false,
+    "**/node_modules": false
+  }
+}

--- a/src/client-transaction.ts
+++ b/src/client-transaction.ts
@@ -4,6 +4,7 @@ import * as Ctx from "effect/Context";
 import * as Data from "effect/Data";
 import * as Effect from "effect/Effect";
 
+// biome-ignore lint/suspicious/noExplicitAny: any client transaction (its Id literal is irrelevant here)
 export type Context<TSchema extends ZeroSchema> = ReturnType<typeof make<any, TSchema>>;
 
 export const make = <const Id extends string, TSchema extends ZeroSchema>(id: Id, schema: TSchema) => {

--- a/src/client-transaction.ts
+++ b/src/client-transaction.ts
@@ -1,24 +1,26 @@
 import type { Schema as ZeroSchema, Transaction as ZeroTransaction } from "@rocicorp/zero";
 import * as Cause from "effect/Cause";
-import * as Context from "effect/Context";
+import * as Ctx from "effect/Context";
 import * as Data from "effect/Data";
 import * as Effect from "effect/Effect";
 
+export type Context<TSchema extends ZeroSchema> = ReturnType<typeof make<any, TSchema>>;
+
 export const make = <const Id extends string, TSchema extends ZeroSchema>(id: Id, schema: TSchema) => {
-  class ClientTransaction extends Context.Service<ClientTransaction, ZeroTransaction<TSchema>>()(id) {}
+  class Context extends Ctx.Service<Context, ZeroTransaction<TSchema>>()(id) {}
 
   const use = <A>(
     fn: (transaction: ZeroTransaction<TSchema>, options: { readonly signal: AbortSignal }) => PromiseLike<A>,
   ) =>
     Effect.gen(function* () {
-      const transaction = yield* ClientTransaction;
+      const transaction = yield* Context;
       return yield* Effect.tryPromise({
         try: (signal) => fn(transaction, { signal }),
         catch: (error) => new ClientTransactionError({ cause: Cause.fail(error) }),
       });
     });
 
-  return { ClientTransaction, use, schema };
+  return { Context, use, schema };
 };
 
 class ClientTransactionError extends Data.TaggedError("ClientTransactionError")<{

--- a/src/client-transaction.ts
+++ b/src/client-transaction.ts
@@ -4,25 +4,21 @@ import * as Context from "effect/Context";
 import * as Data from "effect/Data";
 import * as Effect from "effect/Effect";
 
-// Necessary workaround for TS declaration generation
-export interface ClientTransaction {
-  readonly _tag: unique symbol;
-}
-
 export const make = <const Id extends string, TSchema extends ZeroSchema>(id: Id, schema: TSchema) => {
-  const ClientTransaction = Context.Tag(id)<ClientTransaction, ZeroTransaction<TSchema>>();
+  class ClientTransaction extends Context.Service<ClientTransaction, ZeroTransaction<TSchema>>()(id) {}
 
   const use = <A>(
     fn: (transaction: ZeroTransaction<TSchema>, options: { readonly signal: AbortSignal }) => PromiseLike<A>,
   ) =>
-    Effect.flatMap(ClientTransaction, (transaction) =>
-      Effect.tryPromise({
+    Effect.gen(function* () {
+      const transaction = yield* ClientTransaction;
+      return yield* Effect.tryPromise({
         try: (signal) => fn(transaction, { signal }),
         catch: (error) => new ClientTransactionError({ cause: Cause.fail(error) }),
-      }),
-    );
+      });
+    });
 
-  return Object.assign(ClientTransaction, { use, schema });
+  return { ClientTransaction, use, schema };
 };
 
 class ClientTransactionError extends Data.TaggedError("ClientTransactionError")<{

--- a/src/client.ts
+++ b/src/client.ts
@@ -10,19 +10,14 @@ import * as Schema from "effect/Schema";
 import type * as ClientTransaction from "./client-transaction.js";
 import * as Mutators from "./mutators.js";
 
-type ClientTransactionContext<TSchema extends ZeroSchema> = Omit<
-  ReturnType<typeof ClientTransaction.make<string, TSchema>>,
-  "use"
->;
-
 export const make = Effect.fn(function* <TSchema extends ZeroSchema, TMutators extends Mutators.AnyMutators>(
-  transaction: ClientTransactionContext<TSchema>,
+  transaction: ClientTransaction.Context<TSchema>,
   mutators: TMutators,
   options: Omit<ZeroOptions<TSchema, UnwrapMutators<TSchema, TMutators>>, "schema" | "mutators">,
 ) {
   const ctx =
     yield* Effect.context<
-      Exclude<Mutators.ExtractMutatorsRequirements<TMutators>, ClientTransaction.ClientTransaction>
+      Exclude<Mutators.ExtractMutatorsRequirements<TMutators>, (typeof transaction.Context)["Identifier"]>
     >();
 
   function unwrapMutator<E>(mutator: Mutators.AnyMutator<Mutators.ExtractMutatorsRequirements<TMutators>, E>) {
@@ -30,8 +25,8 @@ export const make = Effect.fn(function* <TSchema extends ZeroSchema, TMutators e
       const exit = await Schema.decodeUnknownEffect(mutator[Mutators.MutatorSchemaSymbol])(args).pipe(
         Effect.catchTag("SchemaError", (e) => Effect.fail(new ClientArgsParseError({ cause: Cause.fail(e) }))),
         Effect.flatMap(mutator),
-        Effect.provideService(transaction, tx),
-        Effect.runPromiseExitWith(ctx),
+        Effect.provideService(transaction.Context, tx),
+        (effect) => Effect.runPromiseExitWith(ctx)(effect),
       );
       if (Exit.isFailure(exit)) {
         // Extract underlying error bypassing FiberFailure

--- a/src/client.ts
+++ b/src/client.ts
@@ -26,7 +26,7 @@ export const make = Effect.fn(function* <TSchema extends ZeroSchema, TMutators e
         Effect.catchTag("SchemaError", (e) => Effect.fail(new ClientArgsParseError({ cause: Cause.fail(e) }))),
         Effect.flatMap(mutator),
         Effect.provideService(transaction.Context, tx),
-        (effect) => Effect.runPromiseExitWith(ctx)(effect),
+        Effect.runPromiseExitWith(ctx),
       );
       if (Exit.isFailure(exit)) {
         // Extract underlying error bypassing FiberFailure

--- a/src/internal/server-synchronization-context.ts
+++ b/src/internal/server-synchronization-context.ts
@@ -62,4 +62,3 @@ export const finalize = <A, E, R>(effect: Effect.Effect<A, E, R>) =>
       ),
     );
   });
-

--- a/src/server-transaction.ts
+++ b/src/server-transaction.ts
@@ -12,26 +12,22 @@ import * as Effect from "effect/Effect";
 import * as Exit from "effect/Exit";
 import * as Layer from "effect/Layer";
 import * as Predicate from "effect/Predicate";
-import type * as ClientTransaction from "./client-transaction.js";
+import type * as ClientTransactionModule from "./client-transaction.js";
 import { MutationAlreadyProcessedError, OutOfOrderMutationError, ServerTransactionInput } from "./internal/server.js";
 import * as ServerSynchronizationContext from "./internal/server-synchronization-context.js";
 import { prefixId } from "./internal/utils.js";
 
 // Updated to: https://github.com/rocicorp/mono/blob/3082c9fa061891067b4bd7dc9fe74f798270d8d7/packages/zero-server/src/push-processor.ts
 
-export interface ServerTransactionContext {
-  readonly _tag: unique symbol;
-}
-
 export const make = <const Id extends string, TSchema extends ZeroSchema, TTransaction>(
   id: Id,
   database: ZQLDatabase<TSchema, TTransaction>,
-  clientTransaction: Context.TagClass<ClientTransaction.ClientTransaction, string, ZeroTransaction<TSchema>>,
+  clientTransaction: ReturnType<typeof ClientTransactionModule.make<string, TSchema>>,
 ) => {
-  const ServerTransactionContext = Context.Tag(`${id}/ServerTransactionContext` as const)<
+  class ServerTransactionContext extends Context.Service<
     ServerTransactionContext,
     { transaction: ZeroServerTransaction<TSchema, TTransaction>; transactionHooks: TransactionProviderHooks }
-  >();
+  >()(`${id}/ServerTransactionContext` as const) {}
 
   const use = <A>(
     fn: (
@@ -39,16 +35,18 @@ export const make = <const Id extends string, TSchema extends ZeroSchema, TTrans
       options: { readonly signal: AbortSignal },
     ) => PromiseLike<A>,
   ) =>
-    Effect.flatMap(ServerTransactionContext, (ctx) =>
-      Effect.tryPromise({
+    Effect.gen(function* () {
+      const ctx = yield* ServerTransactionContext;
+      return yield* Effect.tryPromise({
         try: (signal) => fn(ctx.transaction, { signal }),
         catch: (error) => new ServerTransactionError({ cause: Cause.fail(error) }),
-      }),
-    );
+      });
+    });
 
   const execute = Effect.fn(function* <A, E, R>(effect: Effect.Effect<A, E, R>) {
     const ctx = yield* Effect.context<
-      ServerTransactionInput | Exclude<R, ClientTransaction.ClientTransaction | ServerTransactionContext>
+      | ServerTransactionInput
+      | Exclude<R, InstanceType<typeof clientTransaction.ClientTransaction> | ServerTransactionContext>
     >();
     const result = yield* Deferred.make<A, E | Effect.Error<typeof checkAndIncrementLastMutationId>>();
 
@@ -59,7 +57,7 @@ export const make = <const Id extends string, TSchema extends ZeroSchema, TTrans
           const exit = await Effect.flatMap(checkAndIncrementLastMutationId, () => effect).pipe(
             Effect.provide([
               Layer.succeed(ServerTransactionContext, { transaction, transactionHooks }),
-              Layer.succeed(clientTransaction, transaction),
+              Layer.succeed(clientTransaction.ClientTransaction, transaction),
             ]),
             (effect) => Effect.runPromiseExitWith(ctx)(effect, { signal }),
           );
@@ -114,7 +112,7 @@ export const make = <const Id extends string, TSchema extends ZeroSchema, TTrans
     }
   });
 
-  return Object.assign(ServerTransactionContext, { use, execute });
+  return { ServerTransactionContext, use, execute };
 };
 
 class ServerTransactionError extends Data.TaggedError("ServerTransactionError")<{

--- a/src/server-transaction.ts
+++ b/src/server-transaction.ts
@@ -1,43 +1,30 @@
-import type {
-  Schema as ZeroSchema,
-  ServerTransaction as ZeroServerTransaction,
-  Transaction as ZeroTransaction,
-} from "@rocicorp/zero";
-import type {
-  TransactionProviderHooks,
-  ZQLDatabase,
-} from "@rocicorp/zero/server";
+import type { Schema as ZeroSchema, ServerTransaction as ZeroServerTransaction } from "@rocicorp/zero";
+import type { TransactionProviderHooks, ZQLDatabase } from "@rocicorp/zero/server";
 import * as Cause from "effect/Cause";
-import * as Context from "effect/Context";
+import * as Ctx from "effect/Context";
 import * as Data from "effect/Data";
 import * as Deferred from "effect/Deferred";
 import * as Effect from "effect/Effect";
 import * as Exit from "effect/Exit";
 import * as Layer from "effect/Layer";
 import * as Predicate from "effect/Predicate";
-import type * as ClientTransactionModule from "./client-transaction.js";
-import {
-  MutationAlreadyProcessedError,
-  OutOfOrderMutationError,
-  ServerTransactionInput,
-} from "./internal/server.js";
+import type * as ClientTransaction from "./client-transaction.js";
+import { MutationAlreadyProcessedError, OutOfOrderMutationError, ServerTransactionInput } from "./internal/server.js";
 import * as ServerSynchronizationContext from "./internal/server-synchronization-context.js";
 import { prefixId } from "./internal/utils.js";
 
 // Updated to: https://github.com/rocicorp/mono/blob/3082c9fa061891067b4bd7dc9fe74f798270d8d7/packages/zero-server/src/push-processor.ts
 
-export const make = <
-  const Id extends string,
-  TSchema extends ZeroSchema,
-  TTransaction,
->(
+export type Context<TSchema extends ZeroSchema, TTransaction> = ReturnType<typeof make<any, TSchema, TTransaction>>;
+
+export const make = <const Id extends string, TSchema extends ZeroSchema, TTransaction>(
   id: Id,
   database: ZQLDatabase<TSchema, TTransaction>,
   // biome-ignore lint/suspicious/noExplicitAny: any client transaction (its Id literal is irrelevant here)
-  clientTransaction: ReturnType<typeof ClientTransactionModule.make<any, TSchema>>,
+  clientTransaction: ClientTransaction.Context<TSchema>,
 ) => {
-  class ServerTransactionContext extends Context.Service<
-    ServerTransactionContext,
+  class Context extends Ctx.Service<
+    Context,
     {
       transaction: ZeroServerTransaction<TSchema, TTransaction>;
       transactionHooks: TransactionProviderHooks;
@@ -51,44 +38,30 @@ export const make = <
     ) => PromiseLike<A>,
   ) =>
     Effect.gen(function* () {
-      const ctx = yield* ServerTransactionContext;
+      const ctx = yield* Context;
       return yield* Effect.tryPromise({
         try: (signal) => fn(ctx.transaction, { signal }),
-        catch: (error) =>
-          new ServerTransactionError({ cause: Cause.fail(error) }),
+        catch: (error) => new ServerTransactionError({ cause: Cause.fail(error) }),
       });
     });
 
-  const execute = Effect.fn(function* <A, E, R>(
-    effect: Effect.Effect<A, E, R>,
-  ) {
+  const execute = Effect.fn(function* <A, E, R>(effect: Effect.Effect<A, E, R>) {
     const ctx = yield* Effect.context<
-      | ServerTransactionInput
-      | Exclude<
-          R,
-          | (typeof clientTransaction.ClientTransaction)["Identifier"]
-          | ServerTransactionContext
-        >
+      ServerTransactionInput | Exclude<R, (typeof clientTransaction.Context)["Identifier"] | Context>
     >();
-    const result = yield* Deferred.make<
-      A,
-      E | Effect.Error<typeof checkAndIncrementLastMutationId>
-    >();
+    const result = yield* Deferred.make<A, E | Effect.Error<typeof checkAndIncrementLastMutationId>>();
 
     const transactionInput = yield* ServerTransactionInput;
     yield* Effect.tryPromise({
       try: (signal) =>
         database.transaction(async (transaction, transactionHooks) => {
-          const exit = await Effect.flatMap(
-            checkAndIncrementLastMutationId,
-            () => effect,
-          ).pipe(
+          const exit = await Effect.flatMap(checkAndIncrementLastMutationId, () => effect).pipe(
             Effect.provide([
-              Layer.succeed(ServerTransactionContext, {
+              Layer.succeed(Context, {
                 transaction,
                 transactionHooks,
               }),
-              Layer.succeed(clientTransaction.ClientTransaction, transaction),
+              Layer.succeed(clientTransaction.Context, transaction),
             ]),
             (effect) => Effect.runPromiseExitWith(ctx)(effect, { signal }),
           );
@@ -119,14 +92,12 @@ export const make = <
   }, ServerSynchronizationContext.guard);
 
   const checkAndIncrementLastMutationId = Effect.gen(function* () {
-    const { transactionHooks } = yield* ServerTransactionContext;
-    const { clientID, mutationID: receivedMutationID } =
-      yield* ServerTransactionInput;
+    const { transactionHooks } = yield* Context;
+    const { clientID, mutationID: receivedMutationID } = yield* ServerTransactionInput;
 
     const { lastMutationID } = yield* Effect.tryPromise({
       try: () => transactionHooks.updateClientMutationID(),
-      catch: (error) =>
-        new UpdateClientMutationIdError({ cause: Cause.fail(error) }),
+      catch: (error) => new UpdateClientMutationIdError({ cause: Cause.fail(error) }),
     });
 
     if (receivedMutationID < lastMutationID) {
@@ -145,32 +116,23 @@ export const make = <
     }
   });
 
-  return { ServerTransactionContext, use, execute };
+  return { Context, use, execute };
 };
 
-class ServerTransactionError extends Data.TaggedError(
-  "ServerTransactionError",
-)<{
+class ServerTransactionError extends Data.TaggedError("ServerTransactionError")<{
   readonly cause: Cause.Cause<unknown>;
 }> {}
 
-class UpdateClientMutationIdError extends Data.TaggedError(
-  "UpdateClientMutationIdError",
-)<{
+class UpdateClientMutationIdError extends Data.TaggedError("UpdateClientMutationIdError")<{
   readonly cause: Cause.Cause<unknown>;
 }> {}
 class ZeroDatabaseError extends Data.TaggedError("ZeroDatabaseError")<{
   readonly cause: Cause.Cause<unknown>;
 }> {}
 
-const ServerTransactionUserErrorTypeId = Symbol.for(
-  prefixId("ServerTransactionUserError"),
-);
-class ServerTransactionUserError extends Data.TaggedError(
-  "ServerTransactionUserError",
-) {
-  readonly [ServerTransactionUserErrorTypeId] =
-    ServerTransactionUserErrorTypeId;
+const ServerTransactionUserErrorTypeId = Symbol.for(prefixId("ServerTransactionUserError"));
+class ServerTransactionUserError extends Data.TaggedError("ServerTransactionUserError") {
+  readonly [ServerTransactionUserErrorTypeId] = ServerTransactionUserErrorTypeId;
   static is(e: unknown): e is ServerTransactionUserError {
     return Predicate.hasProperty(e, ServerTransactionUserErrorTypeId);
   }

--- a/src/server-transaction.ts
+++ b/src/server-transaction.ts
@@ -15,20 +15,17 @@ import { prefixId } from "./internal/utils.js";
 
 // Updated to: https://github.com/rocicorp/mono/blob/3082c9fa061891067b4bd7dc9fe74f798270d8d7/packages/zero-server/src/push-processor.ts
 
+// biome-ignore lint/suspicious/noExplicitAny: any client transaction (its Id literal is irrelevant here)
 export type Context<TSchema extends ZeroSchema, TTransaction> = ReturnType<typeof make<any, TSchema, TTransaction>>;
 
 export const make = <const Id extends string, TSchema extends ZeroSchema, TTransaction>(
   id: Id,
   database: ZQLDatabase<TSchema, TTransaction>,
-  // biome-ignore lint/suspicious/noExplicitAny: any client transaction (its Id literal is irrelevant here)
   clientTransaction: ClientTransaction.Context<TSchema>,
 ) => {
   class Context extends Ctx.Service<
     Context,
-    {
-      transaction: ZeroServerTransaction<TSchema, TTransaction>;
-      transactionHooks: TransactionProviderHooks;
-    }
+    { transaction: ZeroServerTransaction<TSchema, TTransaction>; transactionHooks: TransactionProviderHooks }
   >()(`${id}/ServerTransactionContext` as const) {}
 
   const use = <A>(
@@ -57,10 +54,7 @@ export const make = <const Id extends string, TSchema extends ZeroSchema, TTrans
         database.transaction(async (transaction, transactionHooks) => {
           const exit = await Effect.flatMap(checkAndIncrementLastMutationId, () => effect).pipe(
             Effect.provide([
-              Layer.succeed(Context, {
-                transaction,
-                transactionHooks,
-              }),
+              Layer.succeed(Context, { transaction, transactionHooks }),
               Layer.succeed(clientTransaction.Context, transaction),
             ]),
             (effect) => Effect.runPromiseExitWith(ctx)(effect, { signal }),

--- a/src/server-transaction.ts
+++ b/src/server-transaction.ts
@@ -3,7 +3,10 @@ import type {
   ServerTransaction as ZeroServerTransaction,
   Transaction as ZeroTransaction,
 } from "@rocicorp/zero";
-import type { TransactionProviderHooks, ZQLDatabase } from "@rocicorp/zero/server";
+import type {
+  TransactionProviderHooks,
+  ZQLDatabase,
+} from "@rocicorp/zero/server";
 import * as Cause from "effect/Cause";
 import * as Context from "effect/Context";
 import * as Data from "effect/Data";
@@ -13,20 +16,32 @@ import * as Exit from "effect/Exit";
 import * as Layer from "effect/Layer";
 import * as Predicate from "effect/Predicate";
 import type * as ClientTransactionModule from "./client-transaction.js";
-import { MutationAlreadyProcessedError, OutOfOrderMutationError, ServerTransactionInput } from "./internal/server.js";
+import {
+  MutationAlreadyProcessedError,
+  OutOfOrderMutationError,
+  ServerTransactionInput,
+} from "./internal/server.js";
 import * as ServerSynchronizationContext from "./internal/server-synchronization-context.js";
 import { prefixId } from "./internal/utils.js";
 
 // Updated to: https://github.com/rocicorp/mono/blob/3082c9fa061891067b4bd7dc9fe74f798270d8d7/packages/zero-server/src/push-processor.ts
 
-export const make = <const Id extends string, TSchema extends ZeroSchema, TTransaction>(
+export const make = <
+  const Id extends string,
+  TSchema extends ZeroSchema,
+  TTransaction,
+>(
   id: Id,
   database: ZQLDatabase<TSchema, TTransaction>,
-  clientTransaction: ReturnType<typeof ClientTransactionModule.make<string, TSchema>>,
+  // biome-ignore lint/suspicious/noExplicitAny: any client transaction (its Id literal is irrelevant here)
+  clientTransaction: ReturnType<typeof ClientTransactionModule.make<any, TSchema>>,
 ) => {
   class ServerTransactionContext extends Context.Service<
     ServerTransactionContext,
-    { transaction: ZeroServerTransaction<TSchema, TTransaction>; transactionHooks: TransactionProviderHooks }
+    {
+      transaction: ZeroServerTransaction<TSchema, TTransaction>;
+      transactionHooks: TransactionProviderHooks;
+    }
   >()(`${id}/ServerTransactionContext` as const) {}
 
   const use = <A>(
@@ -39,24 +54,40 @@ export const make = <const Id extends string, TSchema extends ZeroSchema, TTrans
       const ctx = yield* ServerTransactionContext;
       return yield* Effect.tryPromise({
         try: (signal) => fn(ctx.transaction, { signal }),
-        catch: (error) => new ServerTransactionError({ cause: Cause.fail(error) }),
+        catch: (error) =>
+          new ServerTransactionError({ cause: Cause.fail(error) }),
       });
     });
 
-  const execute = Effect.fn(function* <A, E, R>(effect: Effect.Effect<A, E, R>) {
+  const execute = Effect.fn(function* <A, E, R>(
+    effect: Effect.Effect<A, E, R>,
+  ) {
     const ctx = yield* Effect.context<
       | ServerTransactionInput
-      | Exclude<R, InstanceType<typeof clientTransaction.ClientTransaction> | ServerTransactionContext>
+      | Exclude<
+          R,
+          | (typeof clientTransaction.ClientTransaction)["Identifier"]
+          | ServerTransactionContext
+        >
     >();
-    const result = yield* Deferred.make<A, E | Effect.Error<typeof checkAndIncrementLastMutationId>>();
+    const result = yield* Deferred.make<
+      A,
+      E | Effect.Error<typeof checkAndIncrementLastMutationId>
+    >();
 
     const transactionInput = yield* ServerTransactionInput;
     yield* Effect.tryPromise({
       try: (signal) =>
         database.transaction(async (transaction, transactionHooks) => {
-          const exit = await Effect.flatMap(checkAndIncrementLastMutationId, () => effect).pipe(
+          const exit = await Effect.flatMap(
+            checkAndIncrementLastMutationId,
+            () => effect,
+          ).pipe(
             Effect.provide([
-              Layer.succeed(ServerTransactionContext, { transaction, transactionHooks }),
+              Layer.succeed(ServerTransactionContext, {
+                transaction,
+                transactionHooks,
+              }),
               Layer.succeed(clientTransaction.ClientTransaction, transaction),
             ]),
             (effect) => Effect.runPromiseExitWith(ctx)(effect, { signal }),
@@ -89,11 +120,13 @@ export const make = <const Id extends string, TSchema extends ZeroSchema, TTrans
 
   const checkAndIncrementLastMutationId = Effect.gen(function* () {
     const { transactionHooks } = yield* ServerTransactionContext;
-    const { clientID, mutationID: receivedMutationID } = yield* ServerTransactionInput;
+    const { clientID, mutationID: receivedMutationID } =
+      yield* ServerTransactionInput;
 
     const { lastMutationID } = yield* Effect.tryPromise({
       try: () => transactionHooks.updateClientMutationID(),
-      catch: (error) => new UpdateClientMutationIdError({ cause: Cause.fail(error) }),
+      catch: (error) =>
+        new UpdateClientMutationIdError({ cause: Cause.fail(error) }),
     });
 
     if (receivedMutationID < lastMutationID) {
@@ -115,20 +148,29 @@ export const make = <const Id extends string, TSchema extends ZeroSchema, TTrans
   return { ServerTransactionContext, use, execute };
 };
 
-class ServerTransactionError extends Data.TaggedError("ServerTransactionError")<{
+class ServerTransactionError extends Data.TaggedError(
+  "ServerTransactionError",
+)<{
   readonly cause: Cause.Cause<unknown>;
 }> {}
 
-class UpdateClientMutationIdError extends Data.TaggedError("UpdateClientMutationIdError")<{
+class UpdateClientMutationIdError extends Data.TaggedError(
+  "UpdateClientMutationIdError",
+)<{
   readonly cause: Cause.Cause<unknown>;
 }> {}
 class ZeroDatabaseError extends Data.TaggedError("ZeroDatabaseError")<{
   readonly cause: Cause.Cause<unknown>;
 }> {}
 
-const ServerTransactionUserErrorTypeId = Symbol.for(prefixId("ServerTransactionUserError"));
-class ServerTransactionUserError extends Data.TaggedError("ServerTransactionUserError") {
-  readonly [ServerTransactionUserErrorTypeId] = ServerTransactionUserErrorTypeId;
+const ServerTransactionUserErrorTypeId = Symbol.for(
+  prefixId("ServerTransactionUserError"),
+);
+class ServerTransactionUserError extends Data.TaggedError(
+  "ServerTransactionUserError",
+) {
+  readonly [ServerTransactionUserErrorTypeId] =
+    ServerTransactionUserErrorTypeId;
   static is(e: unknown): e is ServerTransactionUserError {
     return Predicate.hasProperty(e, ServerTransactionUserErrorTypeId);
   }

--- a/src/server.ts
+++ b/src/server.ts
@@ -27,7 +27,8 @@ import type { TransformRequestMessage } from "./types/queries.js";
 // https://github.com/rocicorp/mono/blob/3082c9fa061891067b4bd7dc9fe74f798270d8d7/packages/zero-server/src/process-mutations.ts
 
 type ServerTransactionContext<TSchema extends ZeroSchema, TTransaction> = Omit<
-  ReturnType<typeof ServerTransaction.make<string, TSchema, TTransaction>>,
+  // biome-ignore lint/suspicious/noExplicitAny: any server transaction (its Id literal is irrelevant here)
+  ReturnType<typeof ServerTransaction.make<any, TSchema, TTransaction>>,
   "use"
 >;
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -26,18 +26,12 @@ import type { TransformRequestMessage } from "./types/queries.js";
 // https://github.com/rocicorp/mono/blob/3082c9fa061891067b4bd7dc9fe74f798270d8d7/packages/zero-server/src/push-processor.ts
 // https://github.com/rocicorp/mono/blob/3082c9fa061891067b4bd7dc9fe74f798270d8d7/packages/zero-server/src/process-mutations.ts
 
-type ServerTransactionContext<TSchema extends ZeroSchema, TTransaction> = Omit<
-  // biome-ignore lint/suspicious/noExplicitAny: any server transaction (its Id literal is irrelevant here)
-  ReturnType<typeof ServerTransaction.make<any, TSchema, TTransaction>>,
-  "use"
->;
-
 export const processPush = Effect.fn(function* <
   TSchema extends ZeroSchema,
   TTransaction,
   TMutators extends Mutators.AnyMutators,
 >(
-  transaction: ServerTransactionContext<TSchema, TTransaction>,
+  transaction: ServerTransaction.Context<TSchema, TTransaction>,
   mutators: TMutators,
   params: Types.PushParams,
   request: Types.PushBody,
@@ -56,7 +50,10 @@ export const processPush = Effect.fn(function* <
         return yield* processMutation<Mutators.ExtractMutatorsRequirements<TMutators>>(mutators, mutation).pipe(
           Effect.catch((e) => processMutationError(transaction, e)),
           Effect.map((result) =>
-            Types.MutationResponse.make({ id: { id: mutation.id, clientID: mutation.clientID }, result }),
+            Types.MutationResponse.make({
+              id: { id: mutation.id, clientID: mutation.clientID },
+              result,
+            }),
           ),
           Effect.provideService(ServerTransactionInput, {
             clientID: mutation.clientID,
@@ -105,12 +102,18 @@ const processMutation = Effect.fn(function* <R>(mutators: Mutators.AnyMutators<R
     Effect.as<Types.MutationResult>({}),
     Effect.catchIf(OutOfOrderMutationError.is, (e) =>
       Effect.logError(e.message).pipe(
-        Effect.as({ error: "oooMutation", details: e.message } satisfies Types.ZeroError),
+        Effect.as({
+          error: "oooMutation",
+          details: e.message,
+        } satisfies Types.ZeroError),
       ),
     ),
     Effect.catchIf(MutationAlreadyProcessedError.is, (e) =>
       Effect.logWarning(e.message).pipe(
-        Effect.as({ error: "alreadyProcessed", details: e.message } satisfies Types.ZeroError),
+        Effect.as({
+          error: "alreadyProcessed",
+          details: e.message,
+        } satisfies Types.ZeroError),
       ),
     ),
     // Case #5 "Zero transactions then fail" / #6 "Fail before transaction"
@@ -120,7 +123,7 @@ const processMutation = Effect.fn(function* <R>(mutators: Mutators.AnyMutators<R
 });
 
 const processMutationError = Effect.fn(function* <TSchema extends ZeroSchema, TTransaction>(
-  transaction: ServerTransactionContext<TSchema, TTransaction>,
+  transaction: ServerTransaction.Context<TSchema, TTransaction>,
   e: unknown,
 ) {
   const { clientID, mutationID } = yield* ServerTransactionInput;
@@ -140,9 +143,13 @@ const processMutationError = Effect.fn(function* <TSchema extends ZeroSchema, TT
   yield* transaction
     .execute(
       Effect.gen(function* () {
-        const { transactionHooks } = yield* transaction;
+        const { transactionHooks } = yield* transaction.Context;
         return yield* Effect.tryPromise({
-          try: () => transactionHooks.writeMutationResult({ id: { id: mutationID, clientID }, result: appError }),
+          try: () =>
+            transactionHooks.writeMutationResult({
+              id: { id: mutationID, clientID },
+              result: appError,
+            }),
           catch: (error) => new WriteMutationResultError({ cause: Cause.fail(error) }),
         });
       }),
@@ -214,7 +221,9 @@ export const handleQuery = Effect.fn(function* <E, R1, R2>(
   });
 });
 
-class QueryNotFound extends Data.TaggedError("QueryNotFound")<{ name: string }> {
+class QueryNotFound extends Data.TaggedError("QueryNotFound")<{
+  name: string;
+}> {
   override get message() {
     return `Query not found: ${this.name}`;
   }
@@ -230,4 +239,6 @@ class QueryUserError<E> extends Data.TaggedError("QueryUserError")<{
   }
 }
 
-class QueryRequestError extends Data.TaggedError("QueryRequestError")<{ cause: Cause.Cause<unknown> }> {}
+class QueryRequestError extends Data.TaggedError("QueryRequestError")<{
+  cause: Cause.Cause<unknown>;
+}> {}

--- a/src/server.ts
+++ b/src/server.ts
@@ -50,10 +50,7 @@ export const processPush = Effect.fn(function* <
         return yield* processMutation<Mutators.ExtractMutatorsRequirements<TMutators>>(mutators, mutation).pipe(
           Effect.catch((e) => processMutationError(transaction, e)),
           Effect.map((result) =>
-            Types.MutationResponse.make({
-              id: { id: mutation.id, clientID: mutation.clientID },
-              result,
-            }),
+            Types.MutationResponse.make({ id: { id: mutation.id, clientID: mutation.clientID }, result }),
           ),
           Effect.provideService(ServerTransactionInput, {
             clientID: mutation.clientID,
@@ -102,18 +99,12 @@ const processMutation = Effect.fn(function* <R>(mutators: Mutators.AnyMutators<R
     Effect.as<Types.MutationResult>({}),
     Effect.catchIf(OutOfOrderMutationError.is, (e) =>
       Effect.logError(e.message).pipe(
-        Effect.as({
-          error: "oooMutation",
-          details: e.message,
-        } satisfies Types.ZeroError),
+        Effect.as({ error: "oooMutation", details: e.message } satisfies Types.ZeroError),
       ),
     ),
     Effect.catchIf(MutationAlreadyProcessedError.is, (e) =>
       Effect.logWarning(e.message).pipe(
-        Effect.as({
-          error: "alreadyProcessed",
-          details: e.message,
-        } satisfies Types.ZeroError),
+        Effect.as({ error: "alreadyProcessed", details: e.message } satisfies Types.ZeroError),
       ),
     ),
     // Case #5 "Zero transactions then fail" / #6 "Fail before transaction"
@@ -145,11 +136,7 @@ const processMutationError = Effect.fn(function* <TSchema extends ZeroSchema, TT
       Effect.gen(function* () {
         const { transactionHooks } = yield* transaction.Context;
         return yield* Effect.tryPromise({
-          try: () =>
-            transactionHooks.writeMutationResult({
-              id: { id: mutationID, clientID },
-              result: appError,
-            }),
+          try: () => transactionHooks.writeMutationResult({ id: { id: mutationID, clientID }, result: appError }),
           catch: (error) => new WriteMutationResultError({ cause: Cause.fail(error) }),
         });
       }),
@@ -221,9 +208,7 @@ export const handleQuery = Effect.fn(function* <E, R1, R2>(
   });
 });
 
-class QueryNotFound extends Data.TaggedError("QueryNotFound")<{
-  name: string;
-}> {
+class QueryNotFound extends Data.TaggedError("QueryNotFound")<{ name: string }> {
   override get message() {
     return `Query not found: ${this.name}`;
   }
@@ -239,6 +224,4 @@ class QueryUserError<E> extends Data.TaggedError("QueryUserError")<{
   }
 }
 
-class QueryRequestError extends Data.TaggedError("QueryRequestError")<{
-  cause: Cause.Cause<unknown>;
-}> {}
+class QueryRequestError extends Data.TaggedError("QueryRequestError")<{ cause: Cause.Cause<unknown> }> {}


### PR DESCRIPTION
## Summary

Round 3a — coupled `Context.Tag` → `Context.Service` migration for `client-transaction.ts` and `server-transaction.ts`, written in the canonical v4 service shape. **Branches off #38 (base PR).**

## What changed

### `client-transaction.ts` and `server-transaction.ts` rewritten in canonical v4 form

```ts
export const make = <const Id extends string, TSchema extends ZeroSchema>(id: Id, schema: TSchema) => {
  class Context extends Ctx.Service<Context, ZeroTransaction<TSchema>>()(id) {}

  const use = <A>(fn) =>
    Effect.gen(function* () {
      const transaction = yield* Context;
      return yield* Effect.tryPromise({ try: ..., catch: ... });
    });

  return { Context, use, schema };
};
```

Removed:
- `Object.assign(ClientTransaction, { use, schema })` — v3 trick to merge custom fields onto the tag class
- `as unknown as Omit<typeof ..., "use"> & { use: ...; schema: ... }` cast that suppressed the inherited `Service.use` overload
- `export interface ClientTransaction { readonly _tag: unique symbol }` and the analogous `ServerTransactionContext` interface — workarounds for TS declaration generation
- `Effect.flatMap(Tag, ctx => ...)` body shape — replaced with `Effect.gen + yield*`
- The internal class is renamed `Context` (factory-local), and the factory return is a plain `{ Context, use, schema }` / `{ Context, use, execute }` object. Module-level `export type Context<...>` aliases provide a stable handle.

### Cross-file Id-generic fix

`server.ts` and `server-transaction.ts` reference each other's factory return types via `ReturnType<typeof X.make<any, ...>>` (rather than `<string, ...>`). Each fresh `make("MyId", schema)` call's inline `class Context` captures `"MyId"` in its nominal identity; widening the parameter's Id to `any` accepts any literal at the call site without losing the per-call class identity.

### Inline `["Identifier"]` brand for in-file R-tracking

Inside `server-transaction.ts` `execute`, the `Effect.context<...>` excludes `(typeof clientTransaction.Context)["Identifier"] | Context` rather than the raw class types. `Identifier` is a stable brand on `Context.Service` instances; using it keeps R-tracking unified across the `Effect.provide` → `runPromiseExitWith` chain. Without it, TS lost the class identity and the resulting `Effect<...>` type didn't satisfy `runPromiseExitWith`'s parameter.

### Caller-side updates

- `client.ts` — `transaction.Context` (instead of using the wrapper as a tag), `Effect.provideService(transaction.Context, tx)`, `Exclude<R, (typeof transaction.Context)["Identifier"]>`.
- `server.ts` — `yield* transaction.Context` (instead of `yield* transaction`); `ServerTransaction.Context<TSchema, TTransaction>` parameter type.

### `.vscode/settings.json` + un-ignore `.vscode/`

Without workspace editor config, Cursor/VSCode fell back to user-global Prettier (printWidth 80) instead of biome (lineWidth 120) — every save reflowed files in a way that fought `bun run lint:fix`. Added `.vscode/settings.json` mirroring sakura2's structure (biome as default formatter for JS/TS/JSON, formatOnSave on, biome explicitly enabled, fixAll on save) and `.vscode/extensions.json` recommending the biome extension. Removed `.vscode` from `.gitignore` so the workspace config can be committed (sakura2 convention). Ran biome lint:fix once on the four PR-relevant files to canonicalize formatting.

## Remaining type issues (4 errors)

All `TS4023` — declaration-generation can't name `NodeInspectSymbol` (transitive from `Context.Service`'s ancestry through `effect/Inspectable`):

```
src/client-transaction.ts:9   error TS4023: Exported variable 'make' has or is using name 'NodeInspectSymbol' from external module "effect/dist/Inspectable" but cannot be named.
src/client.ts:13              same
src/server-transaction.ts:20  same
src/server.ts:29              same
```

These four are the only remaining issues. They surface because the inline-class technique (`class Context extends Ctx.Service<...>(id) {}` inside the factory) leaves the exported function's inferred type closing over a class whose ancestry includes types not nominally reachable from the emitted `.d.ts`. The deleted `interface ClientTransaction { _tag: unique symbol }` was the workaround for exactly this; we removed it because the user explicitly wants no TS-decl-generation workarounds in this round.

## Caveats fully resolved

- ✅ Specific-vs-generic Id mismatch at the factory boundary (was 6 errors at types.test.ts call sites) — fixed by `<any, ...>` in the cross-file return-type signatures.
- ✅ In-file R-tracking through `Effect.provide` → `runPromiseExitWith` — fixed by the `["Identifier"]` brand.
- ✅ All caller-side renames (`transaction.Context`, `yield* transaction.Context`, `Effect.provideService(transaction.Context, ...)`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
