### PR TITLE
Fix TS4023 by importing NodeInspectSymbol in 4 files

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,13 +5,16 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     permissions:
       contents: read
       pull-requests: write
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v3
+      - uses: actions/setup-node@v4
+        with:
+          node-version: lts/*
       - uses: oven-sh/setup-bun@v2
       - uses: docker/setup-compose-action@v1
       - name: Install dependencies

--- a/src/client-transaction.ts
+++ b/src/client-transaction.ts
@@ -3,6 +3,9 @@ import * as Cause from "effect/Cause";
 import * as Ctx from "effect/Context";
 import * as Data from "effect/Data";
 import * as Effect from "effect/Effect";
+import type { NodeInspectSymbol } from "effect/Inspectable";
+
+type _ = NodeInspectSymbol;
 
 // biome-ignore lint/suspicious/noExplicitAny: any client transaction (its Id literal is irrelevant here)
 export type Context<TSchema extends ZeroSchema> = ReturnType<typeof make<any, TSchema>>;

--- a/src/client.ts
+++ b/src/client.ts
@@ -9,6 +9,7 @@ import * as Predicate from "effect/Predicate";
 import * as Rec from "effect/Record";
 import * as Schema from "effect/Schema";
 import type * as ClientTransaction from "./client-transaction.js";
+import { normalizeArgs } from "./internal/utils.js";
 import * as Mutators from "./mutators.js";
 
 type _ = NodeInspectSymbol;
@@ -25,12 +26,7 @@ export const make = Effect.fn(function* <TSchema extends ZeroSchema, TMutators e
 
   function unwrapMutator<E>(mutator: Mutators.AnyMutator<Mutators.ExtractMutatorsRequirements<TMutators>, E>) {
     return async (tx: ZeroTransaction<TSchema>, args: unknown, _ctx: unknown) => {
-      // Zero unconditionally serializes arg-less mutator calls as `null` on the wire
-      // (https://github.com/rocicorp/mono/blob/3082c9fa061891067b4bd7dc9fe74f798270d8d7/packages/zero-client/src/client/custom.ts).
-      // v3 `Schema.Void` happened to accept any input; v4 `Schema.Void` is strict
-      // `=== undefined`, so we renormalize before decoding.
-      const input = args === null ? undefined : args;
-      const exit = await Schema.decodeUnknownEffect(mutator[Mutators.MutatorSchemaSymbol])(input).pipe(
+      const exit = await Schema.decodeUnknownEffect(mutator[Mutators.MutatorSchemaSymbol])(normalizeArgs(args)).pipe(
         Effect.catchTag("SchemaError", (e) => Effect.fail(new ClientArgsParseError({ cause: Cause.fail(e) }))),
         Effect.flatMap(mutator),
         Effect.provideService(transaction.Context, tx),

--- a/src/client.ts
+++ b/src/client.ts
@@ -25,7 +25,12 @@ export const make = Effect.fn(function* <TSchema extends ZeroSchema, TMutators e
 
   function unwrapMutator<E>(mutator: Mutators.AnyMutator<Mutators.ExtractMutatorsRequirements<TMutators>, E>) {
     return async (tx: ZeroTransaction<TSchema>, args: unknown, _ctx: unknown) => {
-      const exit = await Schema.decodeUnknownEffect(mutator[Mutators.MutatorSchemaSymbol])(args).pipe(
+      // Zero unconditionally serializes arg-less mutator calls as `null` on the wire
+      // (https://github.com/rocicorp/mono/blob/3082c9fa061891067b4bd7dc9fe74f798270d8d7/packages/zero-client/src/client/custom.ts).
+      // v3 `Schema.Void` happened to accept any input; v4 `Schema.Void` is strict
+      // `=== undefined`, so we renormalize before decoding.
+      const input = args === null ? undefined : args;
+      const exit = await Schema.decodeUnknownEffect(mutator[Mutators.MutatorSchemaSymbol])(input).pipe(
         Effect.catchTag("SchemaError", (e) => Effect.fail(new ClientArgsParseError({ cause: Cause.fail(e) }))),
         Effect.flatMap(mutator),
         Effect.provideService(transaction.Context, tx),

--- a/src/client.ts
+++ b/src/client.ts
@@ -3,12 +3,15 @@ import * as Cause from "effect/Cause";
 import * as Data from "effect/Data";
 import * as Effect from "effect/Effect";
 import * as Exit from "effect/Exit";
+import type { NodeInspectSymbol } from "effect/Inspectable";
 import * as Match from "effect/Match";
 import * as Predicate from "effect/Predicate";
 import * as Rec from "effect/Record";
 import * as Schema from "effect/Schema";
 import type * as ClientTransaction from "./client-transaction.js";
 import * as Mutators from "./mutators.js";
+
+type _ = NodeInspectSymbol;
 
 export const make = Effect.fn(function* <TSchema extends ZeroSchema, TMutators extends Mutators.AnyMutators>(
   transaction: ClientTransaction.Context<TSchema>,

--- a/src/internal/server.test.ts
+++ b/src/internal/server.test.ts
@@ -7,9 +7,8 @@ import { NoTransactionError } from "./server.js";
 import * as ServerSynchronizationContext from "./server-synchronization-context.js";
 
 describe("ServerSynchronizationContext", () => {
-  it.effect(
-    "finalize should return NoTransactionError when called without guard",
-    Effect.fn(function* () {
+  it.effect("finalize should return NoTransactionError when called without guard", () =>
+    Effect.gen(function* () {
       const result = yield* Effect.void.pipe(
         ServerSynchronizationContext.finalize,
         Effect.provide(ServerSynchronizationContext.layer),

--- a/src/internal/utils.ts
+++ b/src/internal/utils.ts
@@ -2,3 +2,11 @@
  * Prefix a string with the package name.
  */
 export const prefixId = <S extends string>(name: S) => `effect-zero/${name}` as const;
+
+/**
+ * Zero unconditionally serializes arg-less mutator calls as `null` on the wire
+ * (https://github.com/rocicorp/mono/blob/3082c9fa061891067b4bd7dc9fe74f798270d8d7/packages/zero-client/src/client/custom.ts).
+ * v3 `Schema.Void` happened to accept any input; v4 `Schema.Void` is strict
+ * `=== undefined`, so we renormalize before decoding.
+ */
+export const normalizeArgs = (args: unknown): unknown => (args === null ? undefined : args);

--- a/src/server-transaction.ts
+++ b/src/server-transaction.ts
@@ -6,6 +6,7 @@ import * as Data from "effect/Data";
 import * as Deferred from "effect/Deferred";
 import * as Effect from "effect/Effect";
 import * as Exit from "effect/Exit";
+import type { NodeInspectSymbol } from "effect/Inspectable";
 import * as Layer from "effect/Layer";
 import * as Predicate from "effect/Predicate";
 import type * as ClientTransaction from "./client-transaction.js";
@@ -14,6 +15,8 @@ import * as ServerSynchronizationContext from "./internal/server-synchronization
 import { prefixId } from "./internal/utils.js";
 
 // Updated to: https://github.com/rocicorp/mono/blob/3082c9fa061891067b4bd7dc9fe74f798270d8d7/packages/zero-server/src/push-processor.ts
+
+type _ = NodeInspectSymbol;
 
 // biome-ignore lint/suspicious/noExplicitAny: any client transaction (its Id literal is irrelevant here)
 export type Context<TSchema extends ZeroSchema, TTransaction> = ReturnType<typeof make<any, TSchema, TTransaction>>;

--- a/src/server-transaction.ts
+++ b/src/server-transaction.ts
@@ -29,7 +29,7 @@ export const make = <const Id extends string, TSchema extends ZeroSchema, TTrans
   class Context extends Ctx.Service<
     Context,
     { transaction: ZeroServerTransaction<TSchema, TTransaction>; transactionHooks: TransactionProviderHooks }
-  >()(`${id}/ServerTransactionContext` as const) {}
+  >()(`${id as string}/ServerTransactionContext` as const) {}
 
   const use = <A>(
     fn: (

--- a/src/server.ts
+++ b/src/server.ts
@@ -6,6 +6,7 @@ import * as Data from "effect/Data";
 import * as Effect from "effect/Effect";
 import * as Exit from "effect/Exit";
 import * as Fn from "effect/Function";
+import type { NodeInspectSymbol } from "effect/Inspectable";
 import * as Match from "effect/Match";
 import * as Option from "effect/Option";
 import * as Predicate from "effect/Predicate";
@@ -25,6 +26,8 @@ import type { TransformRequestMessage } from "./types/queries.js";
 // Updated to:
 // https://github.com/rocicorp/mono/blob/3082c9fa061891067b4bd7dc9fe74f798270d8d7/packages/zero-server/src/push-processor.ts
 // https://github.com/rocicorp/mono/blob/3082c9fa061891067b4bd7dc9fe74f798270d8d7/packages/zero-server/src/process-mutations.ts
+
+type _ = NodeInspectSymbol;
 
 export const processPush = Effect.fn(function* <
   TSchema extends ZeroSchema,

--- a/src/server.ts
+++ b/src/server.ts
@@ -16,7 +16,7 @@ import * as Stream from "effect/Stream";
 import * as Str from "effect/String";
 import { MutationAlreadyProcessedError, OutOfOrderMutationError, ServerTransactionInput } from "./internal/server.js";
 import * as ServerSynchronizationContext from "./internal/server-synchronization-context.js";
-import { prefixId } from "./internal/utils.js";
+import { normalizeArgs, prefixId } from "./internal/utils.js";
 import * as Mutators from "./mutators.js";
 import { type MakeQueryResult, QueryNameSymbol, RunQuerySymbol } from "./query.js";
 import type * as ServerTransaction from "./server-transaction.js";
@@ -93,14 +93,9 @@ const processMutation = Effect.fn(function* <R>(mutators: Mutators.AnyMutators<R
     Effect.catchTag("NoSuchElementError", () => Effect.fail(new MutatorNotFoundError({ name: mutation.name }))),
   );
 
-  // Zero unconditionally serializes arg-less mutator calls as `null` on the wire
-  // (https://github.com/rocicorp/mono/blob/3082c9fa061891067b4bd7dc9fe74f798270d8d7/packages/zero-client/src/client/custom.ts).
-  // v3 `Schema.Void` happened to accept any input; v4 `Schema.Void` is strict
-  // `=== undefined`, so we renormalize before decoding (mirrors client.ts).
-  const rawArgs = mutation.args[0] === null ? undefined : mutation.args[0];
-  const args = yield* Schema.decodeUnknownEffect(mutator[Mutators.MutatorSchemaSymbol])(rawArgs).pipe(
-    Effect.catchTag("SchemaError", (e) => Effect.fail(new ServerArgsParseError({ cause: Cause.fail(e) }))),
-  );
+  const args = yield* Schema.decodeUnknownEffect(mutator[Mutators.MutatorSchemaSymbol])(
+    normalizeArgs(mutation.args[0]),
+  ).pipe(Effect.catchTag("SchemaError", (e) => Effect.fail(new ServerArgsParseError({ cause: Cause.fail(e) }))));
 
   return yield* mutator(args).pipe(
     ServerSynchronizationContext.finalize,

--- a/src/server.ts
+++ b/src/server.ts
@@ -93,7 +93,12 @@ const processMutation = Effect.fn(function* <R>(mutators: Mutators.AnyMutators<R
     Effect.catchTag("NoSuchElementError", () => Effect.fail(new MutatorNotFoundError({ name: mutation.name }))),
   );
 
-  const args = yield* Schema.decodeUnknownEffect(mutator[Mutators.MutatorSchemaSymbol])(mutation.args[0]).pipe(
+  // Zero unconditionally serializes arg-less mutator calls as `null` on the wire
+  // (https://github.com/rocicorp/mono/blob/3082c9fa061891067b4bd7dc9fe74f798270d8d7/packages/zero-client/src/client/custom.ts).
+  // v3 `Schema.Void` happened to accept any input; v4 `Schema.Void` is strict
+  // `=== undefined`, so we renormalize before decoding (mirrors client.ts).
+  const rawArgs = mutation.args[0] === null ? undefined : mutation.args[0];
+  const args = yield* Schema.decodeUnknownEffect(mutator[Mutators.MutatorSchemaSymbol])(rawArgs).pipe(
     Effect.catchTag("SchemaError", (e) => Effect.fail(new ServerArgsParseError({ cause: Cause.fail(e) }))),
   );
 

--- a/tests/bun.lock
+++ b/tests/bun.lock
@@ -46,11 +46,11 @@
 
     "@ecies/ciphers": ["@ecies/ciphers@0.2.6", "", { "peerDependencies": { "@noble/ciphers": "^1.0.0" } }, "sha512-patgsRPKGkhhoBjETV4XxD0En4ui5fbX0hzayqI3M8tvNMGUoUvmyYAIWwlxBc1KX5cturfqByYdj5bYGRpN9g=="],
 
-    "@effect/platform-node": ["@effect/platform-node@4.0.0-beta.64", "", { "dependencies": { "@effect/platform-node-shared": "^4.0.0-beta.64", "mime": "^4.1.0", "undici": "^8.0.2" }, "peerDependencies": { "effect": "^4.0.0-beta.64", "ioredis": "^5.7.0" } }, "sha512-HlY04TBxe1Z2+Jl4dbwG5uHiUpEH6jvasoNtII6oergaHHQbbD8fLgFzHdy09mJTMK5B1O1fSb95Yztu5jwHxw=="],
+    "@effect/platform-node": ["@effect/platform-node@4.0.0-beta.65", "", { "dependencies": { "@effect/platform-node-shared": "^4.0.0-beta.65", "mime": "^4.1.0", "undici": "^8.0.2" }, "peerDependencies": { "effect": "^4.0.0-beta.65", "ioredis": "^5.7.0" } }, "sha512-QQy3KRcMwP0TngQdfQGl2u1zp03B7k7DuF5SNS8aZhD0dDBpKZpCwFad1ODY5qdY3ycPgMwBwKRRK7y/aw0C9w=="],
 
-    "@effect/platform-node-shared": ["@effect/platform-node-shared@4.0.0-beta.64", "", { "dependencies": { "@types/ws": "^8.18.1", "ws": "^8.20.0" }, "peerDependencies": { "effect": "^4.0.0-beta.64" } }, "sha512-F5hVnPZbgKzxy2TijjhNZKqj7tQi60dx1W/JinnsNxYKGuspvW2gDUeqmNw7sP2bEA5ToeGDPqRCRdpHj3sZxg=="],
+    "@effect/platform-node-shared": ["@effect/platform-node-shared@4.0.0-beta.65", "", { "dependencies": { "@types/ws": "^8.18.1", "ws": "^8.20.0" }, "peerDependencies": { "effect": "^4.0.0-beta.65" } }, "sha512-3rY8F3WLEax6Hj08GI/OvDIH+KqjfxH7RM2bAMfgR75NgRmwDtny1P49PtPkoRjH5dcdtThThtsvE4X9OTZkpQ=="],
 
-    "@effect/vitest": ["@effect/vitest@4.0.0-beta.64", "", { "peerDependencies": { "effect": "^4.0.0-beta.64", "vitest": "^3.0.0 || ^4.0.0" } }, "sha512-BI+ju06iC6adB6evHSIz/HTppp9r8Kg1aaoOR6XVUgquLA9h3DJKmR7NWZLh8EXl5fIBI7VXDGpqJVr7MWBUug=="],
+    "@effect/vitest": ["@effect/vitest@4.0.0-beta.65", "", { "peerDependencies": { "effect": "^4.0.0-beta.65", "vitest": "^3.0.0 || ^4.0.0" } }, "sha512-dJdZlQhB+AtMlSgrJ0QiprRhDnGVTcKmPe699+f5qkQjCKauogaAKekWV3xEM1envAMntwqeFUD4QHVnE+cFPg=="],
 
     "@esbuild-kit/core-utils": ["@esbuild-kit/core-utils@3.3.2", "", { "dependencies": { "esbuild": "~0.18.20", "source-map-support": "^0.5.21" } }, "sha512-sPRAnw9CdSsRmEtnsl2WXWdyquogVpB3yZ3dgwJfe8zrOzTsV7cJvmwrKVa+0ma5BoiGJ+BoqkMvawbayKUsqQ=="],
 
@@ -568,7 +568,7 @@
 
     "eciesjs": ["eciesjs@0.4.18", "", { "dependencies": { "@ecies/ciphers": "^0.2.5", "@noble/ciphers": "^1.3.0", "@noble/curves": "^1.9.7", "@noble/hashes": "^1.8.0" } }, "sha512-wG99Zcfcys9fZux7Cft8BAX/YrOJLJSZ3jyYPfhZHqN2E+Ffx+QXBDsv3gubEgPtV6dTzJMSQUwk1H98/t/0wQ=="],
 
-    "effect": ["effect@4.0.0-beta.64", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "fast-check": "^4.6.0", "find-my-way-ts": "^0.1.6", "ini": "^6.0.0", "kubernetes-types": "^1.30.0", "msgpackr": "^1.11.9", "multipasta": "^0.2.7", "toml": "^4.1.1", "uuid": "^13.0.0", "yaml": "^2.8.3" } }, "sha512-xI332I9guVLsqvLg7aO62IuWq9LiCMs+u5dhr4JDyND2ndYXAk5eaR8KMqtYLoJg1Ie28VQToYPM+xBLEBU3pQ=="],
+    "effect": ["effect@4.0.0-beta.65", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "fast-check": "^4.6.0", "find-my-way-ts": "^0.1.6", "ini": "^6.0.0", "kubernetes-types": "^1.30.0", "msgpackr": "^1.11.9", "multipasta": "^0.2.7", "toml": "^4.1.1", "uuid": "^13.0.0", "yaml": "^2.8.3" } }, "sha512-QYKvQPAj3CmtsvWkHQww15wX4KG2gNsszDWEcOO5sZCMknp66u6Si/Opmt3wwWCwsyvRmDAdIg+JIz5qzbbFIw=="],
 
     "effect-zero": ["effect-zero@../package.tgz", { "peerDependencies": { "@rocicorp/zero": "*", "effect": "^4.0.0-beta.64" } }],
 
@@ -954,7 +954,7 @@
 
     "tar-stream": ["tar-stream@2.2.0", "", { "dependencies": { "bl": "^4.0.3", "end-of-stream": "^1.4.1", "fs-constants": "^1.0.0", "inherits": "^2.0.3", "readable-stream": "^3.1.1" } }, "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ=="],
 
-    "thread-stream": ["thread-stream@4.0.0", "", { "dependencies": { "real-require": "^0.2.0" } }, "sha512-4iMVL6HAINXWf1ZKZjIPcz5wYaOdPhtO8ATvZ+Xqp3BTdaqtAwQkNmKORqcIo5YkQqGXq5cwfswDwMqqQNrpJA=="],
+    "thread-stream": ["thread-stream@4.1.0", "", { "dependencies": { "real-require": "^1.0.0" } }, "sha512-Bw6h2iBDt16v6iHLChBIoVYU8CBo9GPsW8TG7h1hRVhqKhIkH6N8qkxNSmiOZTKsCLPbtWG4ViWLkU6KeKXpig=="],
 
     "tinybench": ["tinybench@2.9.0", "", {}, "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg=="],
 
@@ -1143,6 +1143,8 @@
     "rollup/@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
 
     "string_decoder/safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
+
+    "thread-stream/real-require": ["real-require@1.0.0", "", {}, "sha512-P4nbQYQfePJxRSmY+v/KINxVucm4NF3p3s7pJveMTtom52FR4YGltUQLB8idDXwDDWW+eYrWDFbuzUnjoWHF7g=="],
 
     "tsx/esbuild": ["esbuild@0.27.7", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.7", "@esbuild/android-arm": "0.27.7", "@esbuild/android-arm64": "0.27.7", "@esbuild/android-x64": "0.27.7", "@esbuild/darwin-arm64": "0.27.7", "@esbuild/darwin-x64": "0.27.7", "@esbuild/freebsd-arm64": "0.27.7", "@esbuild/freebsd-x64": "0.27.7", "@esbuild/linux-arm": "0.27.7", "@esbuild/linux-arm64": "0.27.7", "@esbuild/linux-ia32": "0.27.7", "@esbuild/linux-loong64": "0.27.7", "@esbuild/linux-mips64el": "0.27.7", "@esbuild/linux-ppc64": "0.27.7", "@esbuild/linux-riscv64": "0.27.7", "@esbuild/linux-s390x": "0.27.7", "@esbuild/linux-x64": "0.27.7", "@esbuild/netbsd-arm64": "0.27.7", "@esbuild/netbsd-x64": "0.27.7", "@esbuild/openbsd-arm64": "0.27.7", "@esbuild/openbsd-x64": "0.27.7", "@esbuild/openharmony-arm64": "0.27.7", "@esbuild/sunos-x64": "0.27.7", "@esbuild/win32-arm64": "0.27.7", "@esbuild/win32-ia32": "0.27.7", "@esbuild/win32-x64": "0.27.7" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w=="],
 

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -276,7 +276,9 @@ const initZero = Effect.gen(function* () {
       stream,
       Stream.filter((d) => Predicate.isTagged(d, "Complete")),
       waitForLastItem,
-      Effect.andThen((d) => Effect.fail(new Error("not empty")).pipe(Effect.when(() => d.value.length > 0))),
+      Effect.andThen((d) =>
+        Effect.fail(new Error("not empty")).pipe(Effect.when(Effect.sync(() => d.value.length > 0))),
+      ),
     );
   }
 

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -244,10 +244,8 @@ const waitForLastItem = Effect.fn("waitForLastItem")(
       stream,
       Stream.timeout(timeout ?? Duration.millis(200)),
       Stream.runLast,
-      Effect.map(
-        Effect.catchTag("NoSuchElementError", () => Effect.fail(new Error("No items received from server"))),
-      ),
-      Effect.flatten,
+      Effect.flatMap(Effect.fromOption),
+      Effect.catchTag("NoSuchElementError", () => Effect.fail(new Error("No items received from server"))),
     );
   },
 );

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -14,7 +14,6 @@ import { beforeEach } from "node:test";
 import { FetchHttpClient, HttpRouter, HttpServer, HttpServerRequest, HttpServerResponse } from "@effect/platform";
 import { NodeHttpServer } from "@effect/platform-node";
 import { beforeAll, expect, expectTypeOf, it, test, vi } from "@effect/vitest";
-import { Atom, Registry } from "@effect-atom/atom";
 import { createBuilder } from "@rocicorp/zero";
 import { zeroDrizzle } from "@rocicorp/zero/server/adapters/drizzle";
 import { count, eq } from "drizzle-orm";
@@ -22,6 +21,8 @@ import { drizzle } from "drizzle-orm/postgres-js";
 import { Chunk, Console, Context, Duration, Effect, Latch, Layer, Option, pipe, Schema, Stream } from "effect";
 import * as Predicate from "effect/Predicate";
 import * as SchemaGetter from "effect/SchemaGetter";
+import * as Atom from "effect/unstable/reactivity/Atom";
+import * as AtomRegistry from "effect/unstable/reactivity/AtomRegistry";
 import * as ZfxClient from "effect-zero/client";
 import * as ZfxClientTransaction from "effect-zero/client-transaction";
 import * as ZfxMutators from "effect-zero/mutators";
@@ -95,11 +96,11 @@ const clientMutators = ZfxMutators.make(mutatorSchema, {
   messages: {
     create: (msg) =>
       clientTransaction.use(async (tx) => {
-        await tx.mutate.messages!.insert(msg);
+        await tx.mutate.messages.insert(msg);
       }),
     updateMessage: Effect.fn(function* (msg: { id: string; body: string }) {
       yield* clientTransaction.use(async (tx) => {
-        await tx.mutate.messages!.update(msg);
+        await tx.mutate.messages.update(msg);
       });
     }),
     deleteAll: Effect.fn(function* () {
@@ -169,7 +170,7 @@ const serverMutators = ZfxMutators.make(mutatorSchema, {
   yieldsErrorAfterTransaction: Effect.fn(function* () {
     yield* serverTransaction
       .use(async (tx) => {
-        await tx.mutate.messages!.insert({ id: nanoid(), body: "hello world" });
+        await tx.mutate.messages.insert({ id: nanoid(), body: "hello world" });
       })
       .pipe(serverTransaction.execute);
     yield* Effect.fail(new Error("error in yieldsErrorAfterTransaction"));
@@ -178,12 +179,12 @@ const serverMutators = ZfxMutators.make(mutatorSchema, {
   doubleTransaction: Effect.fn(function* () {
     yield* serverTransaction
       .use(async (tx) => {
-        await tx.mutate.messages!.insert({ id: nanoid(), body: "hello world" });
+        await tx.mutate.messages.insert({ id: nanoid(), body: "hello world" });
       })
       .pipe(serverTransaction.execute);
     yield* serverTransaction
       .use(async (tx) => {
-        await tx.mutate.messages!.insert({ id: nanoid(), body: "hello world" });
+        await tx.mutate.messages.insert({ id: nanoid(), body: "hello world" });
       })
       .pipe(serverTransaction.execute);
   }),
@@ -192,12 +193,12 @@ const serverMutators = ZfxMutators.make(mutatorSchema, {
       [
         serverTransaction
           .use(async (tx) => {
-            await tx.mutate.messages!.insert({ id: nanoid(), body: "hello world" });
+            await tx.mutate.messages.insert({ id: nanoid(), body: "hello world" });
           })
           .pipe(serverTransaction.execute),
         serverTransaction
           .use(async (tx) => {
-            await tx.mutate.messages!.insert({ id: nanoid(), body: "hello world" });
+            await tx.mutate.messages.insert({ id: nanoid(), body: "hello world" });
           })
           .pipe(serverTransaction.execute),
       ],
@@ -212,7 +213,7 @@ const messageByIdQuery = ZfxQuery.make({
   name: "messageById",
   payload: Schema.String,
   query: Effect.fn(function* (id) {
-    return yield* Effect.succeed(builder.messages!.where("id", id).one());
+    return yield* Effect.succeed(builder.messages.where("id", id).one());
   }),
 });
 
@@ -221,7 +222,7 @@ const messagesQuery = ZfxQuery.make({
   payload: Schema.Void,
   query: Effect.fn(function* () {
     // TODO: figure out why base queries (without `.limit()`) don't receive `completed` events
-    return yield* Effect.succeed(builder.messages!.limit(100));
+    return yield* Effect.succeed(builder.messages.limit(100));
   }),
 });
 
@@ -240,7 +241,7 @@ const transformArgsQuery = ZfxQuery.make({
   query: Effect.fn(function* (a) {
     expectTypeOf<typeof a>().toEqualTypeOf<Date>();
     transformArgsQuerySpy(a);
-    return yield* Effect.succeed(builder.messages!);
+    return yield* Effect.succeed(builder.messages);
   }),
 });
 
@@ -798,105 +799,6 @@ it.live(
 );
 
 it.live(
-  "Query.subscribable should work for singular queries",
-  Effect.fn(function* () {
-    const z = yield* initZero;
-
-    const value: Message = { id: nanoid(), body: "Hello, world!" };
-    yield* Effect.promise(() => ddb.insert(messages).values(value));
-
-    const q = yield* messageByIdQuery(value.id);
-    const sub = ZfxQuery.subscribable(z, q);
-
-    expect(yield* sub.get).toEqual({ _tag: "Partial", value: undefined });
-
-    {
-      const result = yield* pipe(
-        sub.changes,
-        Stream.filter((d) => Predicate.isTagged(d, "Complete")),
-        waitForLastItem,
-      );
-
-      expect(result.value).toEqual(value);
-    }
-  }),
-);
-
-it.live(
-  "Query.subscribable.get should always return the latest value for singular queries",
-  Effect.fn(function* () {
-    const z = yield* initZero;
-
-    const value: Message = { id: nanoid(), body: "Hello, world!" };
-    yield* Effect.promise(() => ddb.insert(messages).values(value));
-
-    const q = yield* messageByIdQuery(value.id);
-    const sub = ZfxQuery.subscribable(z, q);
-
-    expect(yield* sub.get).toEqual(expect.objectContaining({ _tag: "Partial", value: undefined }));
-
-    yield* Effect.sleep(Duration.millis(500));
-
-    expect(yield* sub.get).toEqual({ _tag: "Partial", value: expect.objectContaining(value) });
-  }),
-);
-
-it.live(
-  "Query.subscribable.get should always return the latest value for plural queries",
-  Effect.fn(function* () {
-    const z = yield* initZero;
-
-    const values: Message[] = [
-      { id: nanoid(), body: "Hello, world!" },
-      { id: nanoid(), body: "Hello, world!" },
-    ];
-    yield* Effect.promise(() => ddb.insert(messages).values(values));
-
-    const q = yield* messagesQuery();
-    const sub = ZfxQuery.subscribable(z, q);
-
-    expect(yield* sub.get).toEqual(expect.objectContaining({ _tag: "Partial", value: [] }));
-
-    yield* Effect.sleep(Duration.millis(500));
-
-    expect(yield* sub.get).toEqual({
-      _tag: "Partial",
-      value: expect.arrayContaining(values.map((v) => expect.objectContaining(v))),
-    });
-  }),
-);
-
-it.live(
-  "Query.subscribable should work for plural queries",
-  Effect.fn(function* () {
-    const z = yield* initZero;
-
-    Atom.subscriptionRef;
-
-    const values: Message[] = [
-      { id: nanoid(), body: "Hello, world!" },
-      { id: nanoid(), body: "Hello, world!" },
-    ];
-    yield* Effect.promise(() => ddb.insert(messages).values(values));
-
-    const q = yield* messagesQuery();
-    const sub = ZfxQuery.subscribable(z, q);
-
-    expect(yield* sub.get).toEqual({ _tag: "Partial", value: [] });
-
-    {
-      const result = yield* pipe(
-        sub.changes,
-        Stream.filter((d) => Predicate.isTagged(d, "Complete")),
-        waitForLastItem,
-      );
-
-      expect(result.value).toEqual(expect.arrayContaining(values));
-    }
-  }),
-);
-
-it.live(
   "Result.acceptPartialMode with 'acceptCached' should work for singular queries",
   Effect.fn(function* () {
     const value: Message = { id: nanoid(), body: "hello world" };
@@ -904,8 +806,7 @@ it.live(
     const z = yield* initZero;
 
     const q = yield* messageByIdQuery(value.id);
-    const sub = ZfxQuery.subscribable(z, q);
-    const atom = Atom.subscribable(Effect.succeed(sub)).pipe(
+    const atom = Atom.make(ZfxQuery.stream(z, q), { initialValue: ZfxQuery.initialValue(q) }).pipe(
       Atom.map(ZfxResult.make),
       Atom.map(ZfxResult.acceptPartialMode("acceptCached")),
     );
@@ -937,7 +838,7 @@ it.live(
         expect.objectContaining({ _tag: "Success", value: newValue }),
       ]);
     }
-  }, Effect.provide(Registry.layer)),
+  }, Effect.provide(AtomRegistry.layer)),
 );
 
 it.live(
@@ -946,8 +847,7 @@ it.live(
     const z = yield* initZero;
 
     const q = yield* messagesQuery();
-    const sub = ZfxQuery.subscribable(z, q);
-    const atom = Atom.subscribable(Effect.succeed(sub)).pipe(
+    const atom = Atom.make(ZfxQuery.stream(z, q), { initialValue: ZfxQuery.initialValue(q) }).pipe(
       Atom.map(ZfxResult.make),
       Atom.map(ZfxResult.acceptPartialMode("acceptCached")),
     );
@@ -983,7 +883,7 @@ it.live(
         expect.objectContaining({ _tag: "Success", value: expect.arrayContaining([...values, newValue]) }),
       ]);
     }
-  }, Effect.provide(Registry.layer)),
+  }, Effect.provide(AtomRegistry.layer)),
 );
 
 it.live(
@@ -994,8 +894,7 @@ it.live(
     const z = yield* initZero;
 
     const q = yield* messageByIdQuery(value.id);
-    const sub = ZfxQuery.subscribable(z, q);
-    const atom = Atom.subscribable(Effect.succeed(sub)).pipe(
+    const atom = Atom.make(ZfxQuery.stream(z, q), { initialValue: ZfxQuery.initialValue(q) }).pipe(
       Atom.map(ZfxResult.make),
       Atom.map(ZfxResult.acceptPartialMode("waitForServer")),
     );
@@ -1025,7 +924,7 @@ it.live(
 
       expect(changes).toEqual([expect.objectContaining({ _tag: "Success", value: newValue })]);
     }
-  }, Effect.provide(Registry.layer)),
+  }, Effect.provide(AtomRegistry.layer)),
 );
 
 it.live(
@@ -1034,8 +933,7 @@ it.live(
     const z = yield* initZero;
 
     const q = yield* messagesQuery();
-    const sub = ZfxQuery.subscribable(z, q);
-    const atom = Atom.subscribable(Effect.succeed(sub)).pipe(
+    const atom = Atom.make(ZfxQuery.stream(z, q), { initialValue: ZfxQuery.initialValue(q) }).pipe(
       Atom.map(ZfxResult.make),
       Atom.map(ZfxResult.acceptPartialMode("waitForServer")),
     );
@@ -1069,5 +967,5 @@ it.live(
         expect.objectContaining({ _tag: "Success", value: expect.arrayContaining([...values, newValue]) }),
       ]);
     }
-  }, Effect.provide(Registry.layer)),
+  }, Effect.provide(AtomRegistry.layer)),
 );

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -11,7 +11,6 @@ dotenv.config({ quiet: true });
 
 import { createServer } from "node:http";
 import { beforeEach } from "node:test";
-import { FetchHttpClient, HttpRouter, HttpServer, HttpServerRequest, HttpServerResponse } from "@effect/platform";
 import { NodeHttpServer } from "@effect/platform-node";
 import { beforeAll, expect, expectTypeOf, it, test, vi } from "@effect/vitest";
 import { createBuilder } from "@rocicorp/zero";
@@ -21,6 +20,10 @@ import { drizzle } from "drizzle-orm/postgres-js";
 import { Chunk, Console, Context, Duration, Effect, Latch, Layer, Option, pipe, Schema, Stream } from "effect";
 import * as Predicate from "effect/Predicate";
 import * as SchemaGetter from "effect/SchemaGetter";
+import * as FetchHttpClient from "effect/unstable/http/FetchHttpClient";
+import * as HttpRouter from "effect/unstable/http/HttpRouter";
+import * as HttpServerRequest from "effect/unstable/http/HttpServerRequest";
+import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
 import * as Atom from "effect/unstable/reactivity/Atom";
 import * as AtomRegistry from "effect/unstable/reactivity/AtomRegistry";
 import * as ZfxClient from "effect-zero/client";
@@ -295,8 +298,9 @@ const initZero = Effect.gen(function* () {
 let responses = Chunk.empty<PushResponse>();
 
 beforeAll(async () => {
-  const router = HttpRouter.empty.pipe(
-    HttpRouter.post(
+  const routes = HttpRouter.addAll([
+    HttpRouter.route(
+      "POST",
       "/push",
       Effect.gen(function* () {
         const params = yield* HttpRouter.schemaParams(PushParams);
@@ -319,7 +323,8 @@ beforeAll(async () => {
         ),
       ),
     ),
-    HttpRouter.post(
+    HttpRouter.route(
+      "POST",
       "/query",
       Effect.gen(function* () {
         const payload = yield* HttpServerRequest.schemaBodyJson(TransformRequestMessage);
@@ -334,13 +339,13 @@ beforeAll(async () => {
         ),
       ),
     ),
-    HttpRouter.get("/health", HttpServerResponse.text("OK")),
-  );
+    HttpRouter.route("GET", "/health", HttpServerResponse.text("OK")),
+  ]);
 
   const server = Effect.gen(function* () {
     const serverStarted = yield* Latch.make();
-    const app = router.pipe(
-      HttpServer.serve(),
+    const app = routes.pipe(
+      HttpRouter.serve,
       Layer.provide(NodeHttpServer.layer(() => createServer(), { port: 3000 })),
       Layer.tap(() => serverStarted.open),
     );

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -21,6 +21,7 @@ import { count, eq } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/postgres-js";
 import { Chunk, Console, Context, Duration, Effect, Latch, Layer, Option, pipe, Schema, Stream } from "effect";
 import * as Predicate from "effect/Predicate";
+import * as SchemaGetter from "effect/SchemaGetter";
 import * as ZfxClient from "effect-zero/client";
 import * as ZfxClientTransaction from "effect-zero/client-transaction";
 import * as ZfxMutators from "effect-zero/mutators";
@@ -226,9 +227,16 @@ const messagesQuery = ZfxQuery.make({
 
 const transformArgsQuerySpy = vi.fn();
 
+const DateFromNumber = Schema.Number.pipe(
+  Schema.decodeTo(Schema.Date, {
+    decode: SchemaGetter.transform((n: number) => new Date(n)),
+    encode: SchemaGetter.transform((d: Date) => d.getTime()),
+  }),
+);
+
 const transformArgsQuery = ZfxQuery.make({
   name: "transformArgs",
-  payload: Schema.DateFromNumber,
+  payload: DateFromNumber,
   query: Effect.fn(function* (a) {
     expectTypeOf<typeof a>().toEqualTypeOf<Date>();
     transformArgsQuerySpy(a);

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -298,49 +298,51 @@ const initZero = Effect.gen(function* () {
 let responses = Chunk.empty<PushResponse>();
 
 beforeAll(async () => {
-  const routes = HttpRouter.addAll([
-    HttpRouter.route(
-      "POST",
-      "/push",
-      Effect.gen(function* () {
-        const params = yield* HttpRouter.schemaParams(PushParams);
-        const payload = yield* HttpServerRequest.schemaBodyJson(PushBody);
-        const result = yield* ZfxServer.processPush(serverTransaction, serverMutators, params, payload);
-        const responseBody = yield* Schema.encodeEffect(PushResponse)(result);
+  const pushRoute = HttpRouter.add(
+    "POST",
+    "/push",
+    Effect.gen(function* () {
+      const params = yield* HttpRouter.schemaParams(PushParams);
+      const payload = yield* HttpServerRequest.schemaBodyJson(PushBody);
+      const result = yield* ZfxServer.processPush(serverTransaction, serverMutators, params, payload);
+      const responseBody = yield* Schema.encodeEffect(PushResponse)(result);
 
-        responses = Chunk.append(responses, responseBody);
+      responses = Chunk.append(responses, responseBody);
 
-        return (yield* HttpServerResponse.json(responseBody)).pipe(
-          HttpServerResponse.setStatus(200),
-          HttpServerResponse.setHeader("content-type", "application/json"),
-        );
-      }).pipe(
-        Effect.catch((e) =>
-          Effect.gen(function* () {
-            yield* Console.error("Push processor error:", e);
-            return HttpServerResponse.empty({ status: 500 });
-          }),
-        ),
+      return (yield* HttpServerResponse.json(responseBody)).pipe(
+        HttpServerResponse.setStatus(200),
+        HttpServerResponse.setHeader("content-type", "application/json"),
+      );
+    }).pipe(
+      Effect.catch((e) =>
+        Effect.gen(function* () {
+          yield* Console.error("Push processor error:", e);
+          return HttpServerResponse.empty({ status: 500 });
+        }),
       ),
     ),
-    HttpRouter.route(
-      "POST",
-      "/query",
-      Effect.gen(function* () {
-        const payload = yield* HttpServerRequest.schemaBodyJson(TransformRequestMessage);
-        const response = yield* ZfxServer.handleQuery(queries, schema, payload);
-        return yield* HttpServerResponse.json(response);
-      }).pipe(
-        Effect.catchCause(
-          Effect.fn(function* (c) {
-            yield* Effect.logError("query error:", c);
-            return HttpServerResponse.empty({ status: 500 });
-          }),
-        ),
+  );
+
+  const queryRoute = HttpRouter.add(
+    "POST",
+    "/query",
+    Effect.gen(function* () {
+      const payload = yield* HttpServerRequest.schemaBodyJson(TransformRequestMessage);
+      const response = yield* ZfxServer.handleQuery(queries, schema, payload);
+      return yield* HttpServerResponse.json(response);
+    }).pipe(
+      Effect.catchCause(
+        Effect.fn(function* (c) {
+          yield* Effect.logError("query error:", c);
+          return HttpServerResponse.empty({ status: 500 });
+        }),
       ),
     ),
-    HttpRouter.route("GET", "/health", HttpServerResponse.text("OK")),
-  ]);
+  );
+
+  const healthRoute = HttpRouter.add("GET", "/health", HttpServerResponse.text("OK"));
+
+  const routes = Layer.mergeAll(pushRoute, queryRoute, healthRoute);
 
   const server = Effect.gen(function* () {
     const serverStarted = yield* Latch.make();

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -19,7 +19,7 @@ import { createBuilder } from "@rocicorp/zero";
 import { zeroDrizzle } from "@rocicorp/zero/server/adapters/drizzle";
 import { count, eq } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/postgres-js";
-import { Chunk, Console, Duration, Effect, Layer, Option, pipe, Schema, Stream } from "effect";
+import { Chunk, Console, Context, Duration, Effect, Latch, Layer, Option, pipe, Schema, Stream } from "effect";
 import * as Predicate from "effect/Predicate";
 import * as ZfxClient from "effect-zero/client";
 import * as ZfxClientTransaction from "effect-zero/client-transaction";
@@ -94,11 +94,11 @@ const clientMutators = ZfxMutators.make(mutatorSchema, {
   messages: {
     create: (msg) =>
       clientTransaction.use(async (tx) => {
-        await tx.mutate.messages.insert(msg);
+        await tx.mutate.messages!.insert(msg);
       }),
     updateMessage: Effect.fn(function* (msg: { id: string; body: string }) {
       yield* clientTransaction.use(async (tx) => {
-        await tx.mutate.messages.update(msg);
+        await tx.mutate.messages!.update(msg);
       });
     }),
     deleteAll: Effect.fn(function* () {
@@ -168,7 +168,7 @@ const serverMutators = ZfxMutators.make(mutatorSchema, {
   yieldsErrorAfterTransaction: Effect.fn(function* () {
     yield* serverTransaction
       .use(async (tx) => {
-        await tx.mutate.messages.insert({ id: nanoid(), body: "hello world" });
+        await tx.mutate.messages!.insert({ id: nanoid(), body: "hello world" });
       })
       .pipe(serverTransaction.execute);
     yield* Effect.fail(new Error("error in yieldsErrorAfterTransaction"));
@@ -177,12 +177,12 @@ const serverMutators = ZfxMutators.make(mutatorSchema, {
   doubleTransaction: Effect.fn(function* () {
     yield* serverTransaction
       .use(async (tx) => {
-        await tx.mutate.messages.insert({ id: nanoid(), body: "hello world" });
+        await tx.mutate.messages!.insert({ id: nanoid(), body: "hello world" });
       })
       .pipe(serverTransaction.execute);
     yield* serverTransaction
       .use(async (tx) => {
-        await tx.mutate.messages.insert({ id: nanoid(), body: "hello world" });
+        await tx.mutate.messages!.insert({ id: nanoid(), body: "hello world" });
       })
       .pipe(serverTransaction.execute);
   }),
@@ -191,12 +191,12 @@ const serverMutators = ZfxMutators.make(mutatorSchema, {
       [
         serverTransaction
           .use(async (tx) => {
-            await tx.mutate.messages.insert({ id: nanoid(), body: "hello world" });
+            await tx.mutate.messages!.insert({ id: nanoid(), body: "hello world" });
           })
           .pipe(serverTransaction.execute),
         serverTransaction
           .use(async (tx) => {
-            await tx.mutate.messages.insert({ id: nanoid(), body: "hello world" });
+            await tx.mutate.messages!.insert({ id: nanoid(), body: "hello world" });
           })
           .pipe(serverTransaction.execute),
       ],
@@ -211,7 +211,7 @@ const messageByIdQuery = ZfxQuery.make({
   name: "messageById",
   payload: Schema.String,
   query: Effect.fn(function* (id) {
-    return yield* Effect.succeed(builder.messages.where("id", id).one());
+    return yield* Effect.succeed(builder.messages!.where("id", id).one());
   }),
 });
 
@@ -220,7 +220,7 @@ const messagesQuery = ZfxQuery.make({
   payload: Schema.Void,
   query: Effect.fn(function* () {
     // TODO: figure out why base queries (without `.limit()`) don't receive `completed` events
-    return yield* Effect.succeed(builder.messages.limit(100));
+    return yield* Effect.succeed(builder.messages!.limit(100));
   }),
 });
 
@@ -232,7 +232,7 @@ const transformArgsQuery = ZfxQuery.make({
   query: Effect.fn(function* (a) {
     expectTypeOf<typeof a>().toEqualTypeOf<Date>();
     transformArgsQuerySpy(a);
-    return yield* Effect.succeed(builder.messages);
+    return yield* Effect.succeed(builder.messages!);
   }),
 });
 
@@ -245,7 +245,7 @@ const waitForLastItem = Effect.fn("waitForLastItem")(
       Stream.timeout(timeout ?? Duration.millis(200)),
       Stream.runLast,
       Effect.map(
-        Effect.catchTag("NoSuchElementException", () => Effect.fail(new Error("No items received from server"))),
+        Effect.catchTag("NoSuchElementError", () => Effect.fail(new Error("No items received from server"))),
       ),
       Effect.flatten,
     );
@@ -293,7 +293,7 @@ beforeAll(async () => {
         const params = yield* HttpRouter.schemaParams(PushParams);
         const payload = yield* HttpServerRequest.schemaBodyJson(PushBody);
         const result = yield* ZfxServer.processPush(serverTransaction, serverMutators, params, payload);
-        const responseBody = yield* Schema.encode(PushResponse)(result);
+        const responseBody = yield* Schema.encodeEffect(PushResponse)(result);
 
         responses = Chunk.append(responses, responseBody);
 
@@ -302,7 +302,7 @@ beforeAll(async () => {
           HttpServerResponse.setHeader("content-type", "application/json"),
         );
       }).pipe(
-        Effect.catchAll((e) =>
+        Effect.catch((e) =>
           Effect.gen(function* () {
             yield* Console.error("Push processor error:", e);
             return HttpServerResponse.empty({ status: 500 });
@@ -317,7 +317,7 @@ beforeAll(async () => {
         const response = yield* ZfxServer.handleQuery(queries, schema, payload);
         return yield* HttpServerResponse.json(response);
       }).pipe(
-        Effect.catchAllCause(
+        Effect.catchCause(
           Effect.fn(function* (c) {
             yield* Effect.logError("query error:", c);
             return HttpServerResponse.empty({ status: 500 });
@@ -329,13 +329,13 @@ beforeAll(async () => {
   );
 
   const server = Effect.gen(function* () {
-    const serverStarted = yield* Effect.makeLatch();
+    const serverStarted = yield* Latch.make();
     const app = router.pipe(
       HttpServer.serve(),
       Layer.provide(NodeHttpServer.layer(() => createServer(), { port: 3000 })),
       Layer.tap(() => serverStarted.open),
     );
-    yield* Layer.launch(app).pipe(Effect.forkDaemon);
+    yield* Layer.launch(app).pipe(Effect.forkDetach);
     yield* serverStarted.await;
   }).pipe(Effect.provide(FetchHttpClient.layer));
 
@@ -354,7 +354,7 @@ test("server is running", async () => {
 test("processPush has no extra requirements", () => {
   const effect = ZfxServer.processPush(serverTransaction, serverMutators, {} as any, {} as any);
 
-  expectTypeOf<Effect.Effect.Context<typeof effect>>().toEqualTypeOf<never>();
+  expectTypeOf<Effect.Services<typeof effect>>().toEqualTypeOf<never>();
 });
 
 test("mutators should have correct argument types", () => {
@@ -382,13 +382,9 @@ test("nested mutators using Effect.fn should have correct argument types", () =>
 });
 
 test("mutator requirements should propagate", () => {
-  class DummyTag extends Effect.Service<DummyTag>()("effect-zero/DummyTag", {
-    succeed: {},
-  }) {}
+  class DummyTag extends Context.Service<DummyTag, {}>()("effect-zero/DummyTag") {}
 
-  class DummyTag2 extends Effect.Service<DummyTag2>()("effect-zero/DummyTag2", {
-    succeed: {},
-  }) {}
+  class DummyTag2 extends Context.Service<DummyTag2, {}>()("effect-zero/DummyTag2") {}
 
   const clientTransaction = ZfxClientTransaction.make("DummyClientTransaction", schema);
   const serverTransaction = ZfxServerTransaction.make("DummyServerTransaction", database, clientTransaction);
@@ -406,10 +402,10 @@ test("mutator requirements should propagate", () => {
   });
   const serverEffect = ZfxServer.processPush(serverTransaction, mutators, {} as any, {} as any);
 
-  expectTypeOf<Effect.Effect.Context<typeof serverEffect>>().toEqualTypeOf<DummyTag | DummyTag2>();
+  expectTypeOf<Effect.Services<typeof serverEffect>>().toEqualTypeOf<DummyTag | DummyTag2>();
 });
 
-it.scopedLive(
+it.live(
   "rows are returned after data is inserted",
   Effect.fn(function* () {
     const z = yield* initZero;
@@ -452,7 +448,7 @@ it.scopedLive(
   }),
 );
 
-it.scopedLive(
+it.live(
   "custom mutators work",
   Effect.fn(function* () {
     const z = yield* initZero;
@@ -471,7 +467,7 @@ it.scopedLive(
   }),
 );
 
-it.scopedLive(
+it.live(
   "nested mutators using Effect.fn work",
   Effect.fn(function* () {
     const z = yield* initZero;
@@ -498,7 +494,7 @@ it.scopedLive(
   }),
 );
 
-it.scopedLive(
+it.live(
   "schema validation is applied to mutator arguments",
   Effect.fn(function* () {
     const z = yield* initZero;
@@ -516,13 +512,13 @@ it.scopedLive(
   }),
 );
 
-it.scopedLive(
+it.live(
   "schema transformations are applied to mutator arguments",
   Effect.fn(function* () {
     const z = yield* initZero;
 
     expectTypeOf<Parameters<typeof z.mutate.transformArgs>>().toEqualTypeOf<
-      [Schema.Schema.Encoded<typeof mutatorSchema.transformArgs>]
+      [Schema.Codec.Encoded<typeof mutatorSchema.transformArgs>]
     >();
     expectTypeOf<Parameters<typeof clientMutators.transformArgs>>().toEqualTypeOf<
       [Schema.Schema.Type<typeof mutatorSchema.transformArgs>]
@@ -535,7 +531,7 @@ it.scopedLive(
   }),
 );
 
-it.scopedLive(
+it.live(
   "mutator that throws error should reject",
   Effect.fn(function* () {
     const z = yield* initZero;
@@ -551,7 +547,7 @@ it.scopedLive(
   }),
 );
 
-it.scopedLive(
+it.live(
   "mutator that throws error inside transaction should reject",
   Effect.fn(function* () {
     const z = yield* initZero;
@@ -570,7 +566,7 @@ it.scopedLive(
   }),
 );
 
-it.scopedLive(
+it.live(
   "mutator that throws error after transaction should resolve",
   Effect.fn(function* () {
     const z = yield* initZero;
@@ -579,7 +575,7 @@ it.scopedLive(
   }),
 );
 
-it.scopedLive(
+it.live(
   "client mutator that throws error should reject",
   Effect.fn(function* () {
     const z = yield* initZero;
@@ -605,7 +601,7 @@ it.scopedLive(
   }),
 );
 
-it.scopedLive(
+it.live(
   "mutator that yields error should reject",
   Effect.fn(function* () {
     const z = yield* initZero;
@@ -621,7 +617,7 @@ it.scopedLive(
   }),
 );
 
-it.scopedLive(
+it.live(
   "mutator that yields error inside transaction should reject",
   Effect.fn(function* () {
     const z = yield* initZero;
@@ -637,7 +633,7 @@ it.scopedLive(
   }),
 );
 
-it.scopedLive(
+it.live(
   "mutator that yields error after transaction should resolve",
   Effect.fn(function* () {
     const z = yield* initZero;
@@ -646,7 +642,7 @@ it.scopedLive(
   }),
 );
 
-it.scopedLive(
+it.live(
   "mutator without transaction should reject",
   Effect.fn(function* () {
     const z = yield* initZero;
@@ -662,7 +658,7 @@ it.scopedLive(
   }),
 );
 
-it.scopedLive(
+it.live(
   "mutator that invokes transaction more than once should resolve",
   Effect.fn(function* () {
     const z = yield* initZero;
@@ -671,7 +667,7 @@ it.scopedLive(
   }),
 );
 
-it.scopedLive(
+it.live(
   "out of order mutations should be rejected",
   Effect.fn(function* () {
     const z = yield* initZero;
@@ -695,7 +691,7 @@ it.scopedLive(
   }),
 );
 
-it.scopedLive(
+it.live(
   "non-existing mutator should reject",
   Effect.fn(function* () {
     const mutatorSchema = ZfxMutators.schema({
@@ -721,7 +717,7 @@ it.scopedLive(
   }),
 );
 
-it.scopedLive(
+it.live(
   "concurrent transactions should be resolved",
   Effect.fn(function* () {
     const z = yield* initZero;
@@ -730,7 +726,7 @@ it.scopedLive(
   }),
 );
 
-it.scopedLive(
+it.live(
   "synced queries should work",
   Effect.fn(function* () {
     const z = yield* initZero;
@@ -779,7 +775,7 @@ it.scopedLive(
   10000,
 );
 
-it.scopedLive(
+it.live(
   "transformArgsQuery should accept and passthrough encoded non-JSON args",
   Effect.fn(function* () {
     expectTypeOf<Parameters<typeof transformArgsQuery>>().toEqualTypeOf<[Date]>();
@@ -793,7 +789,7 @@ it.scopedLive(
   }),
 );
 
-it.scopedLive(
+it.live(
   "Query.subscribable should work for singular queries",
   Effect.fn(function* () {
     const z = yield* initZero;
@@ -818,7 +814,7 @@ it.scopedLive(
   }),
 );
 
-it.scopedLive(
+it.live(
   "Query.subscribable.get should always return the latest value for singular queries",
   Effect.fn(function* () {
     const z = yield* initZero;
@@ -837,7 +833,7 @@ it.scopedLive(
   }),
 );
 
-it.scopedLive(
+it.live(
   "Query.subscribable.get should always return the latest value for plural queries",
   Effect.fn(function* () {
     const z = yield* initZero;
@@ -862,7 +858,7 @@ it.scopedLive(
   }),
 );
 
-it.scopedLive(
+it.live(
   "Query.subscribable should work for plural queries",
   Effect.fn(function* () {
     const z = yield* initZero;
@@ -892,7 +888,7 @@ it.scopedLive(
   }),
 );
 
-it.scopedLive(
+it.live(
   "Result.acceptPartialMode with 'acceptCached' should work for singular queries",
   Effect.fn(function* () {
     const value: Message = { id: nanoid(), body: "hello world" };
@@ -916,7 +912,7 @@ it.scopedLive(
     );
 
     {
-      const changes = yield* stream.pipe(Stream.runCollect, Effect.map(Chunk.toArray));
+      const changes = yield* stream.pipe(Stream.runCollect);
 
       expect(changes[changes.length - 1]).toEqual(expect.objectContaining({ _tag: "Success", value }));
     }
@@ -926,7 +922,7 @@ it.scopedLive(
     yield* Effect.promise(() => ddb.update(messages).set({ body: newBody }).where(eq(messages.id, value.id)));
 
     {
-      const changes = yield* stream.pipe(Stream.runCollect, Effect.map(Chunk.toArray));
+      const changes = yield* stream.pipe(Stream.runCollect);
 
       expect(changes).toEqual([
         expect.objectContaining({ _tag: "Success", value }),
@@ -936,7 +932,7 @@ it.scopedLive(
   }, Effect.provide(Registry.layer)),
 );
 
-it.scopedLive(
+it.live(
   "Result.acceptPartialMode with 'acceptCached' should work for plural queries",
   Effect.fn(function* () {
     const z = yield* initZero;
@@ -961,7 +957,7 @@ it.scopedLive(
       Stream.timeout(Duration.millis(200)),
     );
     {
-      const changes = yield* stream.pipe(Stream.runCollect, Effect.map(Chunk.toArray));
+      const changes = yield* stream.pipe(Stream.runCollect);
 
       expect(changes[changes.length - 1]).toEqual(
         expect.objectContaining({ _tag: "Success", value: expect.arrayContaining(values) }),
@@ -972,7 +968,7 @@ it.scopedLive(
     yield* Effect.promise(() => ddb.insert(messages).values(newValue));
 
     {
-      const changes = yield* stream.pipe(Stream.runCollect, Effect.map(Chunk.toArray));
+      const changes = yield* stream.pipe(Stream.runCollect);
 
       expect(changes).toEqual([
         expect.objectContaining({ _tag: "Success", value: expect.arrayContaining(values) }),
@@ -982,7 +978,7 @@ it.scopedLive(
   }, Effect.provide(Registry.layer)),
 );
 
-it.scopedLive(
+it.live(
   "Result.acceptPartialMode with 'waitForServer' should work for singular queries",
   Effect.fn(function* () {
     const value: Message = { id: nanoid(), body: "hello world" };
@@ -1006,7 +1002,7 @@ it.scopedLive(
     );
 
     {
-      const changes = yield* stream.pipe(Stream.runCollect, Effect.map(Chunk.toArray));
+      const changes = yield* stream.pipe(Stream.runCollect);
 
       expect(changes).toEqual([expect.objectContaining({ _tag: "Success", value })]);
     }
@@ -1017,14 +1013,14 @@ it.scopedLive(
     yield* Effect.sleep(Duration.millis(200));
 
     {
-      const changes = yield* stream.pipe(Stream.runCollect, Effect.map(Chunk.toArray));
+      const changes = yield* stream.pipe(Stream.runCollect);
 
       expect(changes).toEqual([expect.objectContaining({ _tag: "Success", value: newValue })]);
     }
   }, Effect.provide(Registry.layer)),
 );
 
-it.scopedLive(
+it.live(
   "Result.acceptPartialMode with 'waitForServer' should work for plural queries",
   Effect.fn(function* () {
     const z = yield* initZero;
@@ -1049,7 +1045,7 @@ it.scopedLive(
       Stream.timeout(Duration.millis(200)),
     );
     {
-      const changes = yield* stream.pipe(Stream.runCollect, Effect.map(Chunk.toArray));
+      const changes = yield* stream.pipe(Stream.runCollect);
 
       expect(changes).toEqual([expect.objectContaining({ _tag: "Success", value: expect.arrayContaining(values) })]);
     }
@@ -1059,7 +1055,7 @@ it.scopedLive(
     yield* Effect.sleep(Duration.millis(200));
 
     {
-      const changes = yield* stream.pipe(Stream.runCollect, Effect.map(Chunk.toArray));
+      const changes = yield* stream.pipe(Stream.runCollect);
 
       expect(changes).toEqual([
         expect.objectContaining({ _tag: "Success", value: expect.arrayContaining([...values, newValue]) }),


### PR DESCRIPTION
## Summary

Minimal fix for the 4 remaining TS4023 errors. **Branches off #38 (base PR).**

## The change — 3 lines per file × 4 files

```diff
+import type { NodeInspectSymbol } from "effect/Inspectable";
+
+type _ = NodeInspectSymbol;
```

Applied to:
- \`src/client-transaction.ts\` (factory definition)
- \`src/server-transaction.ts\` (factory definition)
- \`src/client.ts\` (consumer: takes \`ClientTransaction.Context<TSchema>\` parameter)
- \`src/server.ts\` (consumer: takes \`ServerTransaction.Context<TSchema, TTransaction>\` parameter)

## Why it's needed

The inline \`class Context extends Ctx.Service<...>(id)\` inside each factory inherits \`[NodeInspectSymbol]\` (the Node.js custom-inspect symbol) from \`Context.Service\`'s \`ServiceProto\`. Each exported function whose inferred type closes over that class needs to be able to name \`NodeInspectSymbol\` when declaration-emit runs.

With \`verbatimModuleSyntax: true\` in the tsconfig, tsc will not auto-add an \`import\` to the emitted \`.d.ts\` — it can only emit \`import("path").Name\` references for paths that are already imported in the source. So each file that's a TS4023 site needs to explicitly import \`NodeInspectSymbol\` itself.

The \`type _ = NodeInspectSymbol\` line keeps biome's \`noUnusedImports\` rule from stripping the import. The \`_\` prefix marks the alias as intentionally unused (biome convention), so no \`// biome-ignore\` comment is required.

## How this relates to the v3 workaround

The v3 code used \`export interface ClientTransaction { readonly _tag: unique symbol }\` to anchor the Tag's \`Identifier\` type at module scope. Different mechanic (v3 anchored the tag identity; v4 anchors a transitively-referenced symbol), same spirit — both are minimal, file-local additions that make declaration emit succeed.

## Verification

- \`bun tsc --noEmit\` → 0 errors (was 4 TS4023 errors)
- \`bun lint\` → no new diagnostics from this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)