### PR TITLE
Effect v4 r3b: waitForLastItem Effect.fromOption bridge

### DIFF
--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -244,10 +244,8 @@ const waitForLastItem = Effect.fn("waitForLastItem")(
       stream,
       Stream.timeout(timeout ?? Duration.millis(200)),
       Stream.runLast,
-      Effect.map(
-        Effect.catchTag("NoSuchElementError", () => Effect.fail(new Error("No items received from server"))),
-      ),
-      Effect.flatten,
+      Effect.flatMap(Effect.fromOption),
+      Effect.catchTag("NoSuchElementError", () => Effect.fail(new Error("No items received from server"))),
     );
   },
 );


### PR DESCRIPTION
## Summary

Stacked on top of #54. Fixes Cluster D (Effect.flatten on Option-yielding stream).

`Stream.runLast` returns `Effect<Option<A>>`. The v3 pattern relied on Option being an Effect subtype, so `Effect.map(catchTag("NoSuchElementError", ...))` + `Effect.flatten` could lift `None` to a tagged failure. v4 separates Option from Effect, so we explicitly bridge with `Effect.fromOption`.

## Before

\`\`\`ts
pipe(
  stream,
  Stream.timeout(timeout ?? Duration.millis(200)),
  Stream.runLast,
  Effect.map(
    Effect.catchTag("NoSuchElementError", () => Effect.fail(new Error("No items received from server"))),
  ),
  Effect.flatten,
);
\`\`\`

## After

\`\`\`ts
pipe(
  stream,
  Stream.timeout(timeout ?? Duration.millis(200)),
  Stream.runLast,
  Effect.flatMap(Effect.fromOption),
  Effect.catchTag("NoSuchElementError", () => Effect.fail(new Error("No items received from server"))),
);
\`\`\`

## Canonical reference

This is the same idiom effect-smol itself uses in `McpServer.ts:647`:

https://github.com/Effect-TS/effect/blob/3082c9fa061891067b4bd7dc9fe74f798270d8d7/packages/effect/src/unstable/ai/McpServer.ts#L644-L647

\`Effect.fromOption\` signature (v4):

https://github.com/Effect-TS/effect/blob/3082c9fa061891067b4bd7dc9fe74f798270d8d7/packages/effect/src/Effect.ts#L1935-L1937

## Impact

\`waitForLastItem\` was used in 8 downstream test sites — all of which previously had \`result: unknown\` cascades. Error count drops from 41 → 31 (10 errors resolved: 2 direct in \`waitForLastItem\` + 8 cascades).

Two of those former cascades (lines 812, 886) now surface a different error (\`.value\` missing on \`{_tag: "Complete"}\`) because their upstream \`sub.changes\` is still typed \`unknown\` from the removed \`ZfxQuery.subscribable\` (Cluster A) — those will resolve when Cluster A is fixed.

## Test plan
- [x] \`bunx tsc --noEmit -p tsconfig.json\` in \`tests/\`: 41 → 31 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)