### PR TITLE
Effect v4 r3c: replace Schema.DateFromNumber in tests

### DIFF
--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -21,6 +21,7 @@ import { count, eq } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/postgres-js";
 import { Chunk, Console, Context, Duration, Effect, Latch, Layer, Option, pipe, Schema, Stream } from "effect";
 import * as Predicate from "effect/Predicate";
+import * as SchemaGetter from "effect/SchemaGetter";
 import * as ZfxClient from "effect-zero/client";
 import * as ZfxClientTransaction from "effect-zero/client-transaction";
 import * as ZfxMutators from "effect-zero/mutators";
@@ -226,9 +227,16 @@ const messagesQuery = ZfxQuery.make({
 
 const transformArgsQuerySpy = vi.fn();
 
+const DateFromNumber = Schema.Number.pipe(
+  Schema.decodeTo(Schema.Date, {
+    decode: SchemaGetter.transform((n: number) => new Date(n)),
+    encode: SchemaGetter.transform((d: Date) => d.getTime()),
+  }),
+);
+
 const transformArgsQuery = ZfxQuery.make({
   name: "transformArgs",
-  payload: Schema.DateFromNumber,
+  payload: DateFromNumber,
   query: Effect.fn(function* (a) {
     expectTypeOf<typeof a>().toEqualTypeOf<Date>();
     transformArgsQuerySpy(a);


### PR DESCRIPTION
## Summary

Stacked on top of #54. Fixes Cluster C (Schema.DateFromNumber removed in v4).

Reuses the exact pattern PR #46 introduced for `src/types.test.ts`: a local `DateFromNumber` codec built from `Schema.Number` + `Schema.decodeTo(Schema.Date, ...)` with `SchemaGetter.transform` on both legs.

## Diff

\`\`\`ts
+import * as SchemaGetter from "effect/SchemaGetter";
...
+const DateFromNumber = Schema.Number.pipe(
+  Schema.decodeTo(Schema.Date, {
+    decode: SchemaGetter.transform((n: number) => new Date(n)),
+    encode: SchemaGetter.transform((d: Date) => d.getTime()),
+  }),
+);
+
 const transformArgsQuery = ZfxQuery.make({
   name: "transformArgs",
-  payload: Schema.DateFromNumber,
+  payload: DateFromNumber,
\`\`\`

## Canonical reference

`SchemaGetter.transform` docstring example shows the same shape:

https://github.com/Effect-TS/effect/blob/3082c9fa061891067b4bd7dc9fe74f798270d8d7/packages/effect/src/SchemaGetter.ts#L70-L71

Mirrors the helper introduced in #46:

https://github.com/realms-labs/effect-zero/pull/46/files#diff-7464ed8b0e0fb5b5dca8ff03b2d39c75d5e0a85d6a8c2a78f8c0d6c2a4f1e5c6

## Impact

Error count: 31 → 27 (4 resolved):
- Line 231: `Property 'DateFromNumber' does not exist on type 'typeof Schema'` (direct)
- Line 233: `Type 'Date' does not satisfy the constraint 'never'` (cascade in `expectTypeOf<typeof a>()`)
- Line 781: `Type '[Date]' does not satisfy the constraint` (cascade in `expectTypeOf<Parameters<typeof transformArgsQuery>>()`)
- Line 780: `TestFunction<void, SchemaError | Error, ...>` mismatch — collapses to a generic surviving `unknown`-channel TestFunction error after the `[Date]` cascade is unwound

## Test plan
- [x] `bunx tsc --noEmit -p tsconfig.json` in `tests/`: 31 → 27 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)