### PR TITLE
Effect v4 r3d: subscribable cleanup (drop pure tests, rewrite Atom tests)

### DIFF
--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -14,7 +14,6 @@ import { beforeEach } from "node:test";
 import { FetchHttpClient, HttpRouter, HttpServer, HttpServerRequest, HttpServerResponse } from "@effect/platform";
 import { NodeHttpServer } from "@effect/platform-node";
 import { beforeAll, expect, expectTypeOf, it, test, vi } from "@effect/vitest";
-import { Atom, Registry } from "@effect-atom/atom";
 import { createBuilder } from "@rocicorp/zero";
 import { zeroDrizzle } from "@rocicorp/zero/server/adapters/drizzle";
 import { count, eq } from "drizzle-orm";
@@ -22,6 +21,8 @@ import { drizzle } from "drizzle-orm/postgres-js";
 import { Chunk, Console, Context, Duration, Effect, Latch, Layer, Option, pipe, Schema, Stream } from "effect";
 import * as Predicate from "effect/Predicate";
 import * as SchemaGetter from "effect/SchemaGetter";
+import * as Atom from "effect/unstable/reactivity/Atom";
+import * as AtomRegistry from "effect/unstable/reactivity/AtomRegistry";
 import * as ZfxClient from "effect-zero/client";
 import * as ZfxClientTransaction from "effect-zero/client-transaction";
 import * as ZfxMutators from "effect-zero/mutators";
@@ -798,105 +799,6 @@ it.live(
 );
 
 it.live(
-  "Query.subscribable should work for singular queries",
-  Effect.fn(function* () {
-    const z = yield* initZero;
-
-    const value: Message = { id: nanoid(), body: "Hello, world!" };
-    yield* Effect.promise(() => ddb.insert(messages).values(value));
-
-    const q = yield* messageByIdQuery(value.id);
-    const sub = ZfxQuery.subscribable(z, q);
-
-    expect(yield* sub.get).toEqual({ _tag: "Partial", value: undefined });
-
-    {
-      const result = yield* pipe(
-        sub.changes,
-        Stream.filter((d) => Predicate.isTagged(d, "Complete")),
-        waitForLastItem,
-      );
-
-      expect(result.value).toEqual(value);
-    }
-  }),
-);
-
-it.live(
-  "Query.subscribable.get should always return the latest value for singular queries",
-  Effect.fn(function* () {
-    const z = yield* initZero;
-
-    const value: Message = { id: nanoid(), body: "Hello, world!" };
-    yield* Effect.promise(() => ddb.insert(messages).values(value));
-
-    const q = yield* messageByIdQuery(value.id);
-    const sub = ZfxQuery.subscribable(z, q);
-
-    expect(yield* sub.get).toEqual(expect.objectContaining({ _tag: "Partial", value: undefined }));
-
-    yield* Effect.sleep(Duration.millis(500));
-
-    expect(yield* sub.get).toEqual({ _tag: "Partial", value: expect.objectContaining(value) });
-  }),
-);
-
-it.live(
-  "Query.subscribable.get should always return the latest value for plural queries",
-  Effect.fn(function* () {
-    const z = yield* initZero;
-
-    const values: Message[] = [
-      { id: nanoid(), body: "Hello, world!" },
-      { id: nanoid(), body: "Hello, world!" },
-    ];
-    yield* Effect.promise(() => ddb.insert(messages).values(values));
-
-    const q = yield* messagesQuery();
-    const sub = ZfxQuery.subscribable(z, q);
-
-    expect(yield* sub.get).toEqual(expect.objectContaining({ _tag: "Partial", value: [] }));
-
-    yield* Effect.sleep(Duration.millis(500));
-
-    expect(yield* sub.get).toEqual({
-      _tag: "Partial",
-      value: expect.arrayContaining(values.map((v) => expect.objectContaining(v))),
-    });
-  }),
-);
-
-it.live(
-  "Query.subscribable should work for plural queries",
-  Effect.fn(function* () {
-    const z = yield* initZero;
-
-    Atom.subscriptionRef;
-
-    const values: Message[] = [
-      { id: nanoid(), body: "Hello, world!" },
-      { id: nanoid(), body: "Hello, world!" },
-    ];
-    yield* Effect.promise(() => ddb.insert(messages).values(values));
-
-    const q = yield* messagesQuery();
-    const sub = ZfxQuery.subscribable(z, q);
-
-    expect(yield* sub.get).toEqual({ _tag: "Partial", value: [] });
-
-    {
-      const result = yield* pipe(
-        sub.changes,
-        Stream.filter((d) => Predicate.isTagged(d, "Complete")),
-        waitForLastItem,
-      );
-
-      expect(result.value).toEqual(expect.arrayContaining(values));
-    }
-  }),
-);
-
-it.live(
   "Result.acceptPartialMode with 'acceptCached' should work for singular queries",
   Effect.fn(function* () {
     const value: Message = { id: nanoid(), body: "hello world" };
@@ -904,8 +806,7 @@ it.live(
     const z = yield* initZero;
 
     const q = yield* messageByIdQuery(value.id);
-    const sub = ZfxQuery.subscribable(z, q);
-    const atom = Atom.subscribable(Effect.succeed(sub)).pipe(
+    const atom = Atom.make(ZfxQuery.stream(z, q), { initialValue: ZfxQuery.initialValue(q) }).pipe(
       Atom.map(ZfxResult.make),
       Atom.map(ZfxResult.acceptPartialMode("acceptCached")),
     );
@@ -937,7 +838,7 @@ it.live(
         expect.objectContaining({ _tag: "Success", value: newValue }),
       ]);
     }
-  }, Effect.provide(Registry.layer)),
+  }, Effect.provide(AtomRegistry.layer)),
 );
 
 it.live(
@@ -946,8 +847,7 @@ it.live(
     const z = yield* initZero;
 
     const q = yield* messagesQuery();
-    const sub = ZfxQuery.subscribable(z, q);
-    const atom = Atom.subscribable(Effect.succeed(sub)).pipe(
+    const atom = Atom.make(ZfxQuery.stream(z, q), { initialValue: ZfxQuery.initialValue(q) }).pipe(
       Atom.map(ZfxResult.make),
       Atom.map(ZfxResult.acceptPartialMode("acceptCached")),
     );
@@ -983,7 +883,7 @@ it.live(
         expect.objectContaining({ _tag: "Success", value: expect.arrayContaining([...values, newValue]) }),
       ]);
     }
-  }, Effect.provide(Registry.layer)),
+  }, Effect.provide(AtomRegistry.layer)),
 );
 
 it.live(
@@ -994,8 +894,7 @@ it.live(
     const z = yield* initZero;
 
     const q = yield* messageByIdQuery(value.id);
-    const sub = ZfxQuery.subscribable(z, q);
-    const atom = Atom.subscribable(Effect.succeed(sub)).pipe(
+    const atom = Atom.make(ZfxQuery.stream(z, q), { initialValue: ZfxQuery.initialValue(q) }).pipe(
       Atom.map(ZfxResult.make),
       Atom.map(ZfxResult.acceptPartialMode("waitForServer")),
     );
@@ -1025,7 +924,7 @@ it.live(
 
       expect(changes).toEqual([expect.objectContaining({ _tag: "Success", value: newValue })]);
     }
-  }, Effect.provide(Registry.layer)),
+  }, Effect.provide(AtomRegistry.layer)),
 );
 
 it.live(
@@ -1034,8 +933,7 @@ it.live(
     const z = yield* initZero;
 
     const q = yield* messagesQuery();
-    const sub = ZfxQuery.subscribable(z, q);
-    const atom = Atom.subscribable(Effect.succeed(sub)).pipe(
+    const atom = Atom.make(ZfxQuery.stream(z, q), { initialValue: ZfxQuery.initialValue(q) }).pipe(
       Atom.map(ZfxResult.make),
       Atom.map(ZfxResult.acceptPartialMode("waitForServer")),
     );
@@ -1069,5 +967,5 @@ it.live(
         expect.objectContaining({ _tag: "Success", value: expect.arrayContaining([...values, newValue]) }),
       ]);
     }
-  }, Effect.provide(Registry.layer)),
+  }, Effect.provide(AtomRegistry.layer)),
 );

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -96,11 +96,11 @@ const clientMutators = ZfxMutators.make(mutatorSchema, {
   messages: {
     create: (msg) =>
       clientTransaction.use(async (tx) => {
-        await tx.mutate.messages!.insert(msg);
+        await tx.mutate.messages.insert(msg);
       }),
     updateMessage: Effect.fn(function* (msg: { id: string; body: string }) {
       yield* clientTransaction.use(async (tx) => {
-        await tx.mutate.messages!.update(msg);
+        await tx.mutate.messages.update(msg);
       });
     }),
     deleteAll: Effect.fn(function* () {
@@ -170,7 +170,7 @@ const serverMutators = ZfxMutators.make(mutatorSchema, {
   yieldsErrorAfterTransaction: Effect.fn(function* () {
     yield* serverTransaction
       .use(async (tx) => {
-        await tx.mutate.messages!.insert({ id: nanoid(), body: "hello world" });
+        await tx.mutate.messages.insert({ id: nanoid(), body: "hello world" });
       })
       .pipe(serverTransaction.execute);
     yield* Effect.fail(new Error("error in yieldsErrorAfterTransaction"));
@@ -179,12 +179,12 @@ const serverMutators = ZfxMutators.make(mutatorSchema, {
   doubleTransaction: Effect.fn(function* () {
     yield* serverTransaction
       .use(async (tx) => {
-        await tx.mutate.messages!.insert({ id: nanoid(), body: "hello world" });
+        await tx.mutate.messages.insert({ id: nanoid(), body: "hello world" });
       })
       .pipe(serverTransaction.execute);
     yield* serverTransaction
       .use(async (tx) => {
-        await tx.mutate.messages!.insert({ id: nanoid(), body: "hello world" });
+        await tx.mutate.messages.insert({ id: nanoid(), body: "hello world" });
       })
       .pipe(serverTransaction.execute);
   }),
@@ -193,12 +193,12 @@ const serverMutators = ZfxMutators.make(mutatorSchema, {
       [
         serverTransaction
           .use(async (tx) => {
-            await tx.mutate.messages!.insert({ id: nanoid(), body: "hello world" });
+            await tx.mutate.messages.insert({ id: nanoid(), body: "hello world" });
           })
           .pipe(serverTransaction.execute),
         serverTransaction
           .use(async (tx) => {
-            await tx.mutate.messages!.insert({ id: nanoid(), body: "hello world" });
+            await tx.mutate.messages.insert({ id: nanoid(), body: "hello world" });
           })
           .pipe(serverTransaction.execute),
       ],
@@ -213,7 +213,7 @@ const messageByIdQuery = ZfxQuery.make({
   name: "messageById",
   payload: Schema.String,
   query: Effect.fn(function* (id) {
-    return yield* Effect.succeed(builder.messages!.where("id", id).one());
+    return yield* Effect.succeed(builder.messages.where("id", id).one());
   }),
 });
 
@@ -222,7 +222,7 @@ const messagesQuery = ZfxQuery.make({
   payload: Schema.Void,
   query: Effect.fn(function* () {
     // TODO: figure out why base queries (without `.limit()`) don't receive `completed` events
-    return yield* Effect.succeed(builder.messages!.limit(100));
+    return yield* Effect.succeed(builder.messages.limit(100));
   }),
 });
 
@@ -241,7 +241,7 @@ const transformArgsQuery = ZfxQuery.make({
   query: Effect.fn(function* (a) {
     expectTypeOf<typeof a>().toEqualTypeOf<Date>();
     transformArgsQuerySpy(a);
-    return yield* Effect.succeed(builder.messages!);
+    return yield* Effect.succeed(builder.messages);
   }),
 });
 


### PR DESCRIPTION
## Summary

Stacked on top of #54. Fixes Cluster A (`ZfxQuery.subscribable`) + B (`Atom.subscribable`) per the direction:
- pure `ZfxQuery.subscribable` tests → delete
- `Atom.subscribable` tests → rewrite to `Atom.make(ZfxQuery.stream(...), { initialValue: ZfxQuery.initialValue(...) })`

## Three moves in one PR

### 1. Delete 4 pure-`ZfxQuery.subscribable` tests

These exercised `.get` / `.changes` on the helper which was removed in #47. No `Atom` involvement.

- `Query.subscribable should work for singular queries`
- `Query.subscribable.get should always return the latest value for singular queries`
- `Query.subscribable.get should always return the latest value for plural queries`
- `Query.subscribable should work for plural queries`

### 2. Rewrite 4 `Atom.subscribable` tests

Structurally equivalent atom — same `.pipe(Atom.map(ZfxResult.make), Atom.map(ZfxResult.acceptPartialMode(...)))` downstream:

\`\`\`diff
-    const sub = ZfxQuery.subscribable(z, q);
-    const atom = Atom.subscribable(Effect.succeed(sub)).pipe(
+    const atom = Atom.make(ZfxQuery.stream(z, q), { initialValue: ZfxQuery.initialValue(q) }).pipe(
       Atom.map(ZfxResult.make),
       Atom.map(ZfxResult.acceptPartialMode("acceptCached")),
     );
\`\`\`

Affected: `acceptPartialMode acceptCached` (singular + plural) and `acceptPartialMode waitForServer` (singular + plural).

### 3. Swap `@effect-atom/atom` → `effect/unstable/reactivity/{Atom,AtomRegistry}`

The installed `@effect-atom/atom@0.4.3` declares `effect@^3.19` as a peer — **it is not v4-compatible**. Its `Result` type has TypeId `"~effect-atom/atom/Result"`, while `src/result.ts` (post-#40) imports `AsyncResult` from `effect/unstable/reactivity/AsyncResult` whose TypeId is `"~effect/reactivity/AsyncResult"`. Different TypeIds → `Atom.map(ZfxResult.make)` cannot unify.

The effect-builtin reactivity `Atom` uses the same `AsyncResult` as `src/result.ts`, so the chain typechecks naturally:

https://github.com/Effect-TS/effect/blob/3082c9fa061891067b4bd7dc9fe74f798270d8d7/packages/effect/src/unstable/reactivity/Atom.ts

\`\`\`diff
-import { Atom, Registry } from "@effect-atom/atom";
+import * as Atom from "effect/unstable/reactivity/Atom";
+import * as AtomRegistry from "effect/unstable/reactivity/AtomRegistry";
\`\`\`

\`Effect.provide(Registry.layer)\` → \`Effect.provide(AtomRegistry.layer)\` (4 sites).

## Impact

Error count: 27 → 5 (22 resolved):
- 8 × `ZfxQuery.subscribable` TS2339 (direct)
- 4 × `Atom.subscribable` TS2345 (direct)
- 4 × `Atom.map(ZfxResult.make)` cascade TS2345
- 4 × TestFunction cascade TS2345 (formerly "Cluster E")
- 2 × `.value` cascade TS2339

Remaining 5 errors are all in unrelated clusters:
- 3 × Cluster F: `processPush` structural mismatch (lines 304, 364, 412)
- 1 × Cluster G: `handleQuery` payload (line 326)
- 1 × Cluster H: `Effect.runPromise` R ≠ never (line 351)

## Test plan
- [x] `bunx tsc --noEmit -p tsconfig.json` in `tests/`: 27 → 5 errors
- [x] `bun run typecheck` (src/) passes
- [ ] Subsequent PRs to fix Clusters F/G/H

🤖 Generated with [Claude Code](https://claude.com/claude-code)