### PR TITLE
Effect v4 r3e: switch tests HTTP from @effect/platform to effect/unstable/http

### DIFF
--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -11,7 +11,6 @@ dotenv.config({ quiet: true });
 
 import { createServer } from "node:http";
 import { beforeEach } from "node:test";
-import { FetchHttpClient, HttpRouter, HttpServer, HttpServerRequest, HttpServerResponse } from "@effect/platform";
 import { NodeHttpServer } from "@effect/platform-node";
 import { beforeAll, expect, expectTypeOf, it, test, vi } from "@effect/vitest";
 import { createBuilder } from "@rocicorp/zero";
@@ -21,6 +20,10 @@ import { drizzle } from "drizzle-orm/postgres-js";
 import { Chunk, Console, Context, Duration, Effect, Latch, Layer, Option, pipe, Schema, Stream } from "effect";
 import * as Predicate from "effect/Predicate";
 import * as SchemaGetter from "effect/SchemaGetter";
+import * as FetchHttpClient from "effect/unstable/http/FetchHttpClient";
+import * as HttpRouter from "effect/unstable/http/HttpRouter";
+import * as HttpServerRequest from "effect/unstable/http/HttpServerRequest";
+import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
 import * as Atom from "effect/unstable/reactivity/Atom";
 import * as AtomRegistry from "effect/unstable/reactivity/AtomRegistry";
 import * as ZfxClient from "effect-zero/client";
@@ -295,8 +298,9 @@ const initZero = Effect.gen(function* () {
 let responses = Chunk.empty<PushResponse>();
 
 beforeAll(async () => {
-  const router = HttpRouter.empty.pipe(
-    HttpRouter.post(
+  const routes = HttpRouter.addAll([
+    HttpRouter.route(
+      "POST",
       "/push",
       Effect.gen(function* () {
         const params = yield* HttpRouter.schemaParams(PushParams);
@@ -319,7 +323,8 @@ beforeAll(async () => {
         ),
       ),
     ),
-    HttpRouter.post(
+    HttpRouter.route(
+      "POST",
       "/query",
       Effect.gen(function* () {
         const payload = yield* HttpServerRequest.schemaBodyJson(TransformRequestMessage);
@@ -334,13 +339,13 @@ beforeAll(async () => {
         ),
       ),
     ),
-    HttpRouter.get("/health", HttpServerResponse.text("OK")),
-  );
+    HttpRouter.route("GET", "/health", HttpServerResponse.text("OK")),
+  ]);
 
   const server = Effect.gen(function* () {
     const serverStarted = yield* Latch.make();
-    const app = router.pipe(
-      HttpServer.serve(),
+    const app = routes.pipe(
+      HttpRouter.serve,
       Layer.provide(NodeHttpServer.layer(() => createServer(), { port: 3000 })),
       Layer.tap(() => serverStarted.open),
     );


### PR DESCRIPTION
## Summary

Stacked on top of #54. Fixes Cluster G (`HttpServerRequest.schemaBodyJson` payload typed as `unknown`).

`@effect/platform@0.90.9` (installed version, and current latest on npm) declares `effect@^3` as a peer dependency — **there is no v4-compatible `@effect/platform` published on npm**. Its `Schema.Schema<A, I, R>` references in the `.d.ts` files don't resolve against v4 `Schema<T>`, so `schemaBodyJson(TransformRequestMessage)` was returning `Effect<unknown, ...>` instead of the decoded tuple.

## Solution

The v4 effect package ships its own in-tree HTTP stack under `effect/unstable/http` (`HttpRouter`, `HttpServer`, `HttpServerRequest`, `HttpServerResponse`, `FetchHttpClient`, ...). Its `schema*` helpers use the proper `Schema.Codec<A, I, RD, RE>` signature, so payloads decode correctly.

Same module boundary effect-smol's own tests use:

https://github.com/Effect-TS/effect/blob/3082c9fa061891067b4bd7dc9fe74f798270d8d7/packages/platform-node/test/NodeHttpServer.test.ts#L11-L25

`@effect/platform-node@4.0.0-beta.65` is v4-compatible and already imports from `effect/unstable/http` internally, so `NodeHttpServer` is kept as-is.

## API shape change

v3 had a chainable router; v4 returns a Layer. Mechanical rewrite of the `beforeAll()` server-setup block; route handler bodies are unchanged:

\`\`\`diff
-const router = HttpRouter.empty.pipe(
-  HttpRouter.post("/push", pushHandler),
-  HttpRouter.post("/query", queryHandler),
-  HttpRouter.get("/health", HttpServerResponse.text("OK")),
-);
+const routes = HttpRouter.addAll([
+  HttpRouter.route("POST", "/push", pushHandler),
+  HttpRouter.route("POST", "/query", queryHandler),
+  HttpRouter.route("GET", "/health", HttpServerResponse.text("OK")),
+]);

 const app = router.pipe(
-  HttpServer.serve(),
+  HttpRouter.serve,
   Layer.provide(NodeHttpServer.layer(() => createServer(), { port: 3000 })),
   Layer.tap(() => serverStarted.open),
 );
\`\`\`

References:
- `HttpRouter.addAll`: https://github.com/Effect-TS/effect/blob/3082c9fa061891067b4bd7dc9fe74f798270d8d7/packages/effect/src/unstable/http/HttpRouter.ts#L156
- `HttpRouter.serve`: https://github.com/Effect-TS/effect/blob/3082c9fa061891067b4bd7dc9fe74f798270d8d7/packages/effect/src/unstable/http/HttpRouter.ts#L1062

## Impact

Error count: 5 → 4 (Cluster G resolved).

**Note on Cluster H** (`Effect.runPromise(server)` at line 356): my earlier analysis was off. Cluster H is *not* a cascade from Cluster G — it's a cascade from **Cluster F** (`processPush` structural mismatch). With Cluster G fixed, the surviving error there shows `Effect<void, never, any>` instead of `Effect<void, never, unknown>`; the `any` leaks from processPush's broken parameter unification, propagating from the route handler → routes Layer → server Effect. Fixing Cluster F will resolve it.

## Test plan
- [x] `bun run typecheck` (src/) passes
- [x] `bunx tsc --noEmit -p tsconfig.json` (tests/) drops from 5 → 4 errors
- [ ] Integration tests at runtime — can't reach until Clusters F+H also resolved

🤖 Generated with [Claude Code](https://claude.com/claude-code)