### PR TITLE
Effect v4 r3f: fix Cluster F (ServerTransaction Context invariance) + residual Cluster H

### DIFF
--- a/src/server-transaction.ts
+++ b/src/server-transaction.ts
@@ -29,7 +29,7 @@ export const make = <const Id extends string, TSchema extends ZeroSchema, TTrans
   class Context extends Ctx.Service<
     Context,
     { transaction: ZeroServerTransaction<TSchema, TTransaction>; transactionHooks: TransactionProviderHooks }
-  >()(`${id}/ServerTransactionContext` as `${string}/ServerTransactionContext`) {}
+  >()(`${id as string}/ServerTransactionContext` as const) {}
 
   const use = <A>(
     fn: (

--- a/src/server-transaction.ts
+++ b/src/server-transaction.ts
@@ -29,7 +29,7 @@ export const make = <const Id extends string, TSchema extends ZeroSchema, TTrans
   class Context extends Ctx.Service<
     Context,
     { transaction: ZeroServerTransaction<TSchema, TTransaction>; transactionHooks: TransactionProviderHooks }
-  >()(`${id}/ServerTransactionContext` as const) {}
+  >()(`${id}/ServerTransactionContext` as `${string}/ServerTransactionContext`) {}
 
   const use = <A>(
     fn: (

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -298,49 +298,51 @@ const initZero = Effect.gen(function* () {
 let responses = Chunk.empty<PushResponse>();
 
 beforeAll(async () => {
-  const routes = HttpRouter.addAll([
-    HttpRouter.route(
-      "POST",
-      "/push",
-      Effect.gen(function* () {
-        const params = yield* HttpRouter.schemaParams(PushParams);
-        const payload = yield* HttpServerRequest.schemaBodyJson(PushBody);
-        const result = yield* ZfxServer.processPush(serverTransaction, serverMutators, params, payload);
-        const responseBody = yield* Schema.encodeEffect(PushResponse)(result);
+  const pushRoute = HttpRouter.add(
+    "POST",
+    "/push",
+    Effect.gen(function* () {
+      const params = yield* HttpRouter.schemaParams(PushParams);
+      const payload = yield* HttpServerRequest.schemaBodyJson(PushBody);
+      const result = yield* ZfxServer.processPush(serverTransaction, serverMutators, params, payload);
+      const responseBody = yield* Schema.encodeEffect(PushResponse)(result);
 
-        responses = Chunk.append(responses, responseBody);
+      responses = Chunk.append(responses, responseBody);
 
-        return (yield* HttpServerResponse.json(responseBody)).pipe(
-          HttpServerResponse.setStatus(200),
-          HttpServerResponse.setHeader("content-type", "application/json"),
-        );
-      }).pipe(
-        Effect.catch((e) =>
-          Effect.gen(function* () {
-            yield* Console.error("Push processor error:", e);
-            return HttpServerResponse.empty({ status: 500 });
-          }),
-        ),
+      return (yield* HttpServerResponse.json(responseBody)).pipe(
+        HttpServerResponse.setStatus(200),
+        HttpServerResponse.setHeader("content-type", "application/json"),
+      );
+    }).pipe(
+      Effect.catch((e) =>
+        Effect.gen(function* () {
+          yield* Console.error("Push processor error:", e);
+          return HttpServerResponse.empty({ status: 500 });
+        }),
       ),
     ),
-    HttpRouter.route(
-      "POST",
-      "/query",
-      Effect.gen(function* () {
-        const payload = yield* HttpServerRequest.schemaBodyJson(TransformRequestMessage);
-        const response = yield* ZfxServer.handleQuery(queries, schema, payload);
-        return yield* HttpServerResponse.json(response);
-      }).pipe(
-        Effect.catchCause(
-          Effect.fn(function* (c) {
-            yield* Effect.logError("query error:", c);
-            return HttpServerResponse.empty({ status: 500 });
-          }),
-        ),
+  );
+
+  const queryRoute = HttpRouter.add(
+    "POST",
+    "/query",
+    Effect.gen(function* () {
+      const payload = yield* HttpServerRequest.schemaBodyJson(TransformRequestMessage);
+      const response = yield* ZfxServer.handleQuery(queries, schema, payload);
+      return yield* HttpServerResponse.json(response);
+    }).pipe(
+      Effect.catchCause(
+        Effect.fn(function* (c) {
+          yield* Effect.logError("query error:", c);
+          return HttpServerResponse.empty({ status: 500 });
+        }),
       ),
     ),
-    HttpRouter.route("GET", "/health", HttpServerResponse.text("OK")),
-  ]);
+  );
+
+  const healthRoute = HttpRouter.add("GET", "/health", HttpServerResponse.text("OK"));
+
+  const routes = Layer.mergeAll(pushRoute, queryRoute, healthRoute);
 
   const server = Effect.gen(function* () {
     const serverStarted = yield* Latch.make();


### PR DESCRIPTION
## Summary

Stacked on top of #54. Fixes Cluster F (\`processPush\` structural mismatch on \`serverTransaction.Context\`) and the residual Cluster H error that surfaced after PR #58.

## Two commits

### 1. \`src/server-transaction.ts\` — widen Context Identifier brand

The root cause of Cluster F:

\`ServerTransaction.Context<TSchema, TTransaction>\` is defined as \`ReturnType<typeof make<any, TSchema, TTransaction>>\`. With the original \`as const\` cast, the resulting Context class baked the specific Id literal into its Identifier brand:

- \`make("ServerTransaction", ...)\` → \`Identifier = "ServerTransaction/ServerTransactionContext"\`
- \`make<any, ...>\` at the type alias → \`Identifier = \\\`\${any}/ServerTransactionContext\\\`\`

\`Ctx.ServiceClass<Self, Identifier, Shape>\` declares \`in out Identifier extends string\` — Identifier is **invariant**. So the concrete literal can't unify with the templated \`\${any}/...\` form even though it matches the template pattern. That mismatch produced the 3 errors at the \`ZfxServer.processPush(serverTransaction, ...)\` call sites (lines 308, 369, 412).

The one-line fix widens the cast:

\`\`\`diff
- >()(\`\${id}/ServerTransactionContext\` as const) {}
+ >()(\`\${id}/ServerTransactionContext\` as \\\`\${string}/ServerTransactionContext\\\`) {}
\`\`\`

Now every \`make()\` invocation produces a Context class with the same Identifier *type* (\`\\\`\${string}/ServerTransactionContext\\\`\`). The runtime value of \`key\` is unchanged — only the type-system widens. Different \`make()\` calls still produce distinct runtime services (different key strings); their types just unify, which is what the type alias wanted in the first place.

### 2. \`tests/index.test.ts\` — \`HttpRouter.add\` + \`Layer.mergeAll\` instead of \`HttpRouter.addAll\`

After Cluster F was resolved, one error remained at \`Effect.runPromise(server)\` (line 356): \`Effect<void, never, any>\` instead of \`Effect<void, never, never>\`. My earlier guess that this was a Cluster F cascade turned out to be wrong — the \`any\` actually leaked from \`HttpRouter.addAll\`'s signature:

\`\`\`ts
addAll: <Routes extends ReadonlyArray<Route<any, any>>, ...>(...)
\`\`\`

\`Route<any, any>\` widens each route's inferred \`<E, R>\` to \`any\`, which then propagates through \`addAll\`'s return Layer's R channel via \`Request.From<"Requires", Exclude<Route.Context<Routes[number]>, Provided>>\`.

\`HttpRouter.add(method, path, handler)\` is \`<E = never, R = never>\` — each Layer preserves the precise \`E\` and \`R\`. Combining them via \`Layer.mergeAll(pushRoute, queryRoute, healthRoute)\` keeps that precision intact:

\`\`\`diff
-const routes = HttpRouter.addAll([
-  HttpRouter.route("POST", "/push", pushHandler),
-  HttpRouter.route("POST", "/query", queryHandler),
-  HttpRouter.route("GET", "/health", HttpServerResponse.text("OK")),
-]);
+const pushRoute = HttpRouter.add("POST", "/push", pushHandler);
+const queryRoute = HttpRouter.add("POST", "/query", queryHandler);
+const healthRoute = HttpRouter.add("GET", "/health", HttpServerResponse.text("OK"));
+const routes = Layer.mergeAll(pushRoute, queryRoute, healthRoute);
\`\`\`

## References

- \`Ctx.ServiceClass\` interface (note \`in out Identifier\`): https://github.com/Effect-TS/effect/blob/3082c9fa061891067b4bd7dc9fe74f798270d8d7/packages/effect/src/Context.ts
- \`HttpRouter.add\`: https://github.com/Effect-TS/effect/blob/3082c9fa061891067b4bd7dc9fe74f798270d8d7/packages/effect/src/unstable/http/HttpRouter.ts (\`export const add\`)
- \`HttpRouter.addAll\` (\`Route<any, any>\` constraint): https://github.com/Effect-TS/effect/blob/3082c9fa061891067b4bd7dc9fe74f798270d8d7/packages/effect/src/unstable/http/HttpRouter.ts (\`export const addAll\`)

## Impact

\`bunx tsc --noEmit -p tsconfig.json\` in \`tests/\`: **4 → 0 errors**.

CI's \`test:types\` step should now pass.

The only remaining CI blocker is the src test failure (\`server.test.ts > finalize should return NoTransactionError when called without guard\`) — v4 \`Effect.fn\` auto-annotates Causes with stack traces, breaking the test's \`deepStrictEqual\`-based assertion. Separate PR.

## Test plan
- [x] \`bun run typecheck\` (src/) passes
- [x] \`bunx tsc --noEmit -p tsconfig.json\` (tests/) drops 4 → 0 errors
- [x] \`bun vitest run src\` passes 38/40 (the 2 remaining failures are the pre-existing src test issue, unrelated)
- [ ] Integration tests at runtime — needs the src test fix + a working zero-cache, deferred

🤖 Generated with [Claude Code](https://claude.com/claude-code)