### PR TITLE
Effect v4 r3g: fix src test by using Effect.gen for cause-equality assertion

### DIFF
--- a/src/internal/server.test.ts
+++ b/src/internal/server.test.ts
@@ -7,9 +7,8 @@ import { NoTransactionError } from "./server.js";
 import * as ServerSynchronizationContext from "./server-synchronization-context.js";
 
 describe("ServerSynchronizationContext", () => {
-  it.effect(
-    "finalize should return NoTransactionError when called without guard",
-    Effect.fn(function* () {
+  it.effect("finalize should return NoTransactionError when called without guard", () =>
+    Effect.gen(function* () {
       const result = yield* Effect.void.pipe(
         ServerSynchronizationContext.finalize,
         Effect.provide(ServerSynchronizationContext.layer),


### PR DESCRIPTION
## Summary

Stacked on top of #54. Fixes the one remaining src-test failure that blocks CI's \`Build & package\` step.

## Root cause

\`assertExitFailure(result, Cause.fail(new NoTransactionError()))\` uses \`deepStrictEqual\` to compare the full \`Cause\`, including its annotations.

v4 \`Effect.fn\` automatically attaches an \`'effect/Cause/StackTrace'\` annotation to every cause that flows through the wrapper:

\`\`\`
+ annotations: Map(1) {
+   'effect/Cause/StackTrace' => {
+     name: 'Effect.fn',
+     parent: { name: 'Effect.fn (definition)', ... },
+     ...
+   }
+ }
- annotations: Map(0) {},
\`\`\`

The ad-hoc \`Cause.fail(new NoTransactionError())\` built in the test has no annotations. \`Map(1) ≠ Map(0)\` → \`deepStrictEqual\` fails.

## Fix

\`Effect.gen\` doesn't annotate causes. Swap the test body from \`Effect.fn\` to \`Effect.gen\`:

\`\`\`diff
-  it.effect(
-    "finalize should return NoTransactionError when called without guard",
-    Effect.fn(function* () {
+  it.effect("finalize should return NoTransactionError when called without guard", () =>
+    Effect.gen(function* () {
       const result = yield* Effect.void.pipe(
         ServerSynchronizationContext.finalize,
         Effect.provide(ServerSynchronizationContext.layer),
         Effect.exit,
       );
       assertExitFailure(result, Cause.fail(new NoTransactionError()));
-    }),
-  );
+    }),
+  );
\`\`\`

The test doesn't need the test-context argument (it uses \`assertExitFailure\` from \`@effect/vitest/utils\`, not \`expect.fail\`), so dropping to \`Effect.gen\` is straightforward.

The sibling test in the same file (\`finalize shouldn't return errors when called with guard\`) keeps \`Effect.fn\` because it destructures \`{ expect }\` from the test context — its assertion path doesn't compare causes, so the auto-annotation is harmless there.

## Why not strip annotations or compare just the inner error

Options considered:
- \`Cause.findError(actual.cause)\` + assert on the unwrapped error — works but loses the "exit is a failure" check
- Compare via \`Exit.isFailure\` then equality on the unwrapped tag/data — same as above, more boilerplate
- Build the expected cause WITH the same annotation — fragile, locks the test to implementation details of Effect.fn's annotation format

Swapping the test wrapper is the smallest correct change. \`Effect.fn\` is a test-runner convenience, not a semantic requirement here.

## Impact

\`bun run test\` (src/): all 40 tests pass (was 38/40).  
\`bun run build\` (test → tsc → attw): all green.

CI's \`Build & package\` step should now pass. Combined with the previous Cluster F PR (#59) — which got \`bun test:types\` to 0 errors — CI is unblocked through both the \`Build & package\` and the \`bun test:types\` portion of the \`Test\` step.

The only remaining unknown is the actual integration tests at runtime (\`bun run test\` inside \`tests/\` against docker-compose + zero-cache). Can't reach that locally without bringing up the full stack.

## Test plan
- [x] \`bun run typecheck\` (src/) passes
- [x] \`bun vitest run src\` — all 40 tests pass
- [x] \`bun run build\` end-to-end (test + tsc + attw) — green

🤖 Generated with [Claude Code](https://claude.com/claude-code)