### PR TITLE
Effect v4 r3i: re-add null-to-undefined arg normalization for Schema.Void mutators

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -25,7 +25,12 @@ export const make = Effect.fn(function* <TSchema extends ZeroSchema, TMutators e
 
   function unwrapMutator<E>(mutator: Mutators.AnyMutator<Mutators.ExtractMutatorsRequirements<TMutators>, E>) {
     return async (tx: ZeroTransaction<TSchema>, args: unknown, _ctx: unknown) => {
-      const exit = await Schema.decodeUnknownEffect(mutator[Mutators.MutatorSchemaSymbol])(args).pipe(
+      // Zero unconditionally serializes arg-less mutator calls as `null` on the wire
+      // (https://github.com/rocicorp/mono/blob/3082c9fa061891067b4bd7dc9fe74f798270d8d7/packages/zero-client/src/client/custom.ts).
+      // v3 `Schema.Void` happened to accept any input; v4 `Schema.Void` is strict
+      // `=== undefined`, so we renormalize before decoding.
+      const input = args === null ? undefined : args;
+      const exit = await Schema.decodeUnknownEffect(mutator[Mutators.MutatorSchemaSymbol])(input).pipe(
         Effect.catchTag("SchemaError", (e) => Effect.fail(new ClientArgsParseError({ cause: Cause.fail(e) }))),
         Effect.flatMap(mutator),
         Effect.provideService(transaction.Context, tx),


### PR DESCRIPTION
## Summary

Stacked on top of #54. Fixes 5 of the integration tests now that CI is actually running them (post-#61).

## Failures observed

After #61's CI fix let vitest actually execute the integration tests, 5 failed with the same shape:

\`\`\`
Expected: { error: { details: '...', type: 'app' } }
Received: { error: { message: 'Poke processing error: ClientArgsParseError', type: 'zero' } }
\`\`\`

All 5 call arg-less mutators (\`Schema.Void\` schemas):
- \`mutator that throws error should reject\`
- \`mutator that yields error should reject\`
- \`mutator that yields error inside transaction should reject\`
- \`mutator without transaction should reject\`
- \`non-existing mutator should reject\`

## Root cause

Zero's client unconditionally serializes arg-less mutator calls as JSON \`null\` on the wire:

https://github.com/rocicorp/mono/blob/3082c9fa061891067b4bd7dc9fe74f798270d8d7/packages/zero-client/src/client/custom.ts

v3 \`Schema.Void\` parser returned \`right(...)\` unconditionally, so \`null\` validated. v4 \`Schema.Void\` uses \`fromConst(this, undefined)\` with strict \`=== undefined\`, so \`null\` is rejected before the mutator body runs — the request fails as \`ClientArgsParseError\` client-side and never reaches the server, so the tests never observe their expected app-level errors.

## Fix

This is the same one-liner that landed in #48 and was removed deliberately ("Ehh actually for now, just remove the normalization entirely") pending runtime validation:

\`\`\`diff
   function unwrapMutator<E>(mutator: ...) {
     return async (tx, args, _ctx) => {
+      // Zero unconditionally serializes arg-less mutator calls as \`null\` on the wire
+      // (https://github.com/rocicorp/mono/.../zero-client/src/client/custom.ts).
+      // v3 \`Schema.Void\` happened to accept any input; v4 \`Schema.Void\` is strict
+      // \`=== undefined\`, so we renormalize before decoding.
+      const input = args === null ? undefined : args;
-      const exit = await Schema.decodeUnknownEffect(mutator[Mutators.MutatorSchemaSymbol])(args).pipe(
+      const exit = await Schema.decodeUnknownEffect(mutator[Mutators.MutatorSchemaSymbol])(input).pipe(
\`\`\`

CI now provides the runtime validation that was missing in #48 — we observably need this back.

## Stacking note

This is stacked on top of #54 directly. The fix won't surface in CI until #61 (\`actions/setup-node\` + ubuntu-24.04) lands too — without #61 the integration tests don't run at all (undici@8 / Node 20 incompatibility).

## Test plan
- [x] \`bun run typecheck\` (src/) passes
- [ ] After #61 lands: re-run CI, expect the 5 failing tests to flip green

🤖 Generated with [Claude Code](https://claude.com/claude-code)