### PR TITLE
Effect v4 r3j: renormalize null args to undefined on the server (mirrors client.ts)

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -93,7 +93,12 @@ const processMutation = Effect.fn(function* <R>(mutators: Mutators.AnyMutators<R
     Effect.catchTag("NoSuchElementError", () => Effect.fail(new MutatorNotFoundError({ name: mutation.name }))),
   );
 
-  const args = yield* Schema.decodeUnknownEffect(mutator[Mutators.MutatorSchemaSymbol])(mutation.args[0]).pipe(
+  // Zero unconditionally serializes arg-less mutator calls as `null` on the wire
+  // (https://github.com/rocicorp/mono/blob/3082c9fa061891067b4bd7dc9fe74f798270d8d7/packages/zero-client/src/client/custom.ts).
+  // v3 `Schema.Void` happened to accept any input; v4 `Schema.Void` is strict
+  // `=== undefined`, so we renormalize before decoding (mirrors client.ts).
+  const rawArgs = mutation.args[0] === null ? undefined : mutation.args[0];
+  const args = yield* Schema.decodeUnknownEffect(mutator[Mutators.MutatorSchemaSymbol])(rawArgs).pipe(
     Effect.catchTag("SchemaError", (e) => Effect.fail(new ServerArgsParseError({ cause: Cause.fail(e) }))),
   );
 


### PR DESCRIPTION
## Summary

Stacked on top of #54. Mirrors #62's fix on the server side.

## What CI showed after #62 landed

5 → 4 failing tests. The four still red are all the existing-mutator-with-Schema.Void cases:

- \`mutator that throws error should reject\`
- \`mutator that yields error should reject\`
- \`mutator that yields error inside transaction should reject\`
- \`mutator without transaction should reject\`

Each one logs:

\`\`\`
[cause]: Error: Cause([Fail(SchemaError(Expected void, got null))])
\`\`\`

So the request now gets past the client (good — that's what #62 fixed), but the server's \`processMutation\` decodes \`mutation.args[0]\` and hits the same v4 \`Schema.Void\` strictness for the same Zero wire-format reason.

The fifth Schema.Void test that flipped to green after #62 (\`non-existing mutator should reject\`) only passes because the server errors out at the mutator lookup step before reaching the arg decode.

## Fix

Same one-liner as #62, applied to \`src/server.ts\` at the only other Schema decode site:

\`\`\`diff
-  const args = yield* Schema.decodeUnknownEffect(mutator[Mutators.MutatorSchemaSymbol])(mutation.args[0]).pipe(
+  // Zero unconditionally serializes arg-less mutator calls as \`null\` on the wire
+  // (https://github.com/rocicorp/mono/.../zero-client/src/client/custom.ts).
+  // v3 \`Schema.Void\` happened to accept any input; v4 \`Schema.Void\` is strict
+  // \`=== undefined\`, so we renormalize before decoding (mirrors client.ts).
+  const rawArgs = mutation.args[0] === null ? undefined : mutation.args[0];
+  const args = yield* Schema.decodeUnknownEffect(mutator[Mutators.MutatorSchemaSymbol])(rawArgs).pipe(
\`\`\`

## Expected impact

\`bun run test\` (tests/) on CI: 24/28 → **28/28**.

## Test plan
- [x] \`bun run typecheck\` (src/) passes
- [ ] After landing in #54: re-run CI, expect 0 failing integration tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)