### PR TITLE
Effect v4 r3k: extract normalizeArgs to internal/utils

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -9,6 +9,7 @@ import * as Predicate from "effect/Predicate";
 import * as Rec from "effect/Record";
 import * as Schema from "effect/Schema";
 import type * as ClientTransaction from "./client-transaction.js";
+import { normalizeArgs } from "./internal/utils.js";
 import * as Mutators from "./mutators.js";
 
 type _ = NodeInspectSymbol;
@@ -25,12 +26,7 @@ export const make = Effect.fn(function* <TSchema extends ZeroSchema, TMutators e
 
   function unwrapMutator<E>(mutator: Mutators.AnyMutator<Mutators.ExtractMutatorsRequirements<TMutators>, E>) {
     return async (tx: ZeroTransaction<TSchema>, args: unknown, _ctx: unknown) => {
-      // Zero unconditionally serializes arg-less mutator calls as `null` on the wire
-      // (https://github.com/rocicorp/mono/blob/3082c9fa061891067b4bd7dc9fe74f798270d8d7/packages/zero-client/src/client/custom.ts).
-      // v3 `Schema.Void` happened to accept any input; v4 `Schema.Void` is strict
-      // `=== undefined`, so we renormalize before decoding.
-      const input = args === null ? undefined : args;
-      const exit = await Schema.decodeUnknownEffect(mutator[Mutators.MutatorSchemaSymbol])(input).pipe(
+      const exit = await Schema.decodeUnknownEffect(mutator[Mutators.MutatorSchemaSymbol])(normalizeArgs(args)).pipe(
         Effect.catchTag("SchemaError", (e) => Effect.fail(new ClientArgsParseError({ cause: Cause.fail(e) }))),
         Effect.flatMap(mutator),
         Effect.provideService(transaction.Context, tx),

--- a/src/internal/utils.ts
+++ b/src/internal/utils.ts
@@ -2,3 +2,11 @@
  * Prefix a string with the package name.
  */
 export const prefixId = <S extends string>(name: S) => `effect-zero/${name}` as const;
+
+/**
+ * Zero unconditionally serializes arg-less mutator calls as `null` on the wire
+ * (https://github.com/rocicorp/mono/blob/3082c9fa061891067b4bd7dc9fe74f798270d8d7/packages/zero-client/src/client/custom.ts).
+ * v3 `Schema.Void` happened to accept any input; v4 `Schema.Void` is strict
+ * `=== undefined`, so we renormalize before decoding.
+ */
+export const normalizeArgs = (args: unknown): unknown => (args === null ? undefined : args);

--- a/src/server.ts
+++ b/src/server.ts
@@ -16,7 +16,7 @@ import * as Stream from "effect/Stream";
 import * as Str from "effect/String";
 import { MutationAlreadyProcessedError, OutOfOrderMutationError, ServerTransactionInput } from "./internal/server.js";
 import * as ServerSynchronizationContext from "./internal/server-synchronization-context.js";
-import { prefixId } from "./internal/utils.js";
+import { normalizeArgs, prefixId } from "./internal/utils.js";
 import * as Mutators from "./mutators.js";
 import { type MakeQueryResult, QueryNameSymbol, RunQuerySymbol } from "./query.js";
 import type * as ServerTransaction from "./server-transaction.js";
@@ -93,14 +93,9 @@ const processMutation = Effect.fn(function* <R>(mutators: Mutators.AnyMutators<R
     Effect.catchTag("NoSuchElementError", () => Effect.fail(new MutatorNotFoundError({ name: mutation.name }))),
   );
 
-  // Zero unconditionally serializes arg-less mutator calls as `null` on the wire
-  // (https://github.com/rocicorp/mono/blob/3082c9fa061891067b4bd7dc9fe74f798270d8d7/packages/zero-client/src/client/custom.ts).
-  // v3 `Schema.Void` happened to accept any input; v4 `Schema.Void` is strict
-  // `=== undefined`, so we renormalize before decoding (mirrors client.ts).
-  const rawArgs = mutation.args[0] === null ? undefined : mutation.args[0];
-  const args = yield* Schema.decodeUnknownEffect(mutator[Mutators.MutatorSchemaSymbol])(rawArgs).pipe(
-    Effect.catchTag("SchemaError", (e) => Effect.fail(new ServerArgsParseError({ cause: Cause.fail(e) }))),
-  );
+  const args = yield* Schema.decodeUnknownEffect(mutator[Mutators.MutatorSchemaSymbol])(
+    normalizeArgs(mutation.args[0]),
+  ).pipe(Effect.catchTag("SchemaError", (e) => Effect.fail(new ServerArgsParseError({ cause: Cause.fail(e) }))));
 
   return yield* mutator(args).pipe(
     ServerSynchronizationContext.finalize,


### PR DESCRIPTION
## Summary

Stacked on top of #54. Pure refactor — no behavior change.

After #62 (client) and #63 (server) landed, the same one-liner plus the same multi-line explanation comment lived in two places:

\`\`\`ts
// Zero unconditionally serializes arg-less mutator calls as \`null\` on the wire
// (https://github.com/rocicorp/mono/.../zero-client/src/client/custom.ts).
// v3 \`Schema.Void\` happened to accept any input; v4 \`Schema.Void\` is strict
// \`=== undefined\`, so we renormalize before decoding.
const input = args === null ? undefined : args;
\`\`\`

Pulled out to \`src/internal/utils.ts\` (alongside \`prefixId\`) so the comment has one canonical home and both call sites just import the function:

\`\`\`ts
// src/internal/utils.ts
export const normalizeArgs = (args: unknown): unknown => (args === null ? undefined : args);

// src/client.ts
Schema.decodeUnknownEffect(...)(normalizeArgs(args))

// src/server.ts
Schema.decodeUnknownEffect(...)(normalizeArgs(mutation.args[0]))
\`\`\`

## Test plan
- [x] \`bun run typecheck\` (src/) passes
- [x] \`bun vitest run src\` — 40/40 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)