### PR TITLE
tests: bump initZero waitForLastItem timeout to 2s (fix #38 CI flake)

### DIFF
--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -285,7 +285,7 @@ const initZero = Effect.gen(function* () {
     yield* pipe(
       stream,
       Stream.filter((d) => Predicate.isTagged(d, "Complete")),
-      waitForLastItem,
+      (s) => waitForLastItem(s, Duration.seconds(2)),
       Effect.andThen((d) =>
         Effect.fail(new Error("not empty")).pipe(Effect.when(Effect.sync(() => d.value.length > 0))),
       ),


### PR DESCRIPTION
## Summary
- Stacked on top of #38. PR#38's CI was failing on `nested mutators using Effect.fn work` with `Error: No items received from server`, even though identical tree content passed CI on #54 (which #38 includes).
- Root cause: `initZero` waits up to 200ms for the Zero query stream to deliver a `Complete` event after `truncate messages`. When CI is slow, that doesn't arrive in time and `Stream.runLast` returns `None`, which `waitForLastItem` maps to the failure above. Whichever test runs first after a prior test left rows in `messages` hits the flake -- in this run it was `nested mutators using Effect.fn work`.
- Fix: pass `Duration.seconds(2)` to `waitForLastItem` at the `initZero` call site. Other `waitForLastItem` usages in this file already pass 500ms; `initZero` is test setup and isn't latency-sensitive.

## Why this is a flake, not a regression
- PR#54 head commit `7499d78` and PR#38 head commit `f6771b0` have **identical trees** (`fd56d645b...`).
- The same code ran green on #54's CI run [25667592970](https://github.com/realms-labs/effect-zero/actions/runs/25667592970) and red on #38's run [25667634719](https://github.com/realms-labs/effect-zero/actions/runs/25667634719) -- pure timing variance.

## Test plan
- [ ] CI green on this PR