### PR TITLE
Add bunfig.toml with 1-day minimum release age

### DIFF
--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,0 +1,2 @@
+[install]
+minimumReleaseAge = 86400


### PR DESCRIPTION
## Summary
- Adds a root-level `bunfig.toml` setting `minimumReleaseAge = 86400` (1 day in seconds) under `[install]`, so `bun install` will skip package versions published less than 1 day ago.

## Test plan
- [ ] `bun install` runs without errors and respects the new release-age floor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)