### PR TITLE
bump 0.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "effect-zero",
   "type": "module",
-  "version": "0.4.2",
+  "version": "0.5.0",
   "license": "MIT",
   "repository": {
     "url": "https://github.com/realms-labs/effect-zero"


### PR DESCRIPTION
Stable `0.5.0` release — version-only bump on top of the merged Effect v4 migration (#38).

This promotes the v4 work (previously published as `0.5.0-beta.0` / `0.5.0-beta.1` under the npm `next` tag) to the stable line. Once merged, dispatch the **Publish** workflow on `main` to publish `0.5.0` to the npm `latest` tag.