### PR TITLE
Replace processPush with handleMutate wrapping upstream handleMutateRequest (#34)

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ export const mutatorSchema = Mutators.schema({
 // server.ts
 
 import { zeroPostgresJS } from "@rocicorp/zero/server/adapters/postgresjs";
-import { PushResponse, PushParams, PushBody } from "effect-zero/types/push";
+import { PushParams, PushBody } from "effect-zero/types/push";
 import * as ServerTransaction from "effect-zero/server-transaction";
 import * as Mutators from "effect-zero/mutators";
 import * as Server from "effect-zero/server";
@@ -107,9 +107,9 @@ export async function handleZeroPush(req: Request): Promise<Response> {
   });
   const payload = Schema.decodeSync(PushBody)(await req.json());
 
-  const result = await Effect.runPromise(Server.processPush(serverTransaction, serverMutators, urlParams, payload));
-  const responseBody = Schema.encodeSync(PushResponse)(result);
-  return new Response(JSON.stringify(responseBody), { status: 200, headers: { "content-type": "application/json" } });
+  // `handleMutate` returns the push response already in wire format, so it can be serialized directly.
+  const result = await Effect.runPromise(Server.handleMutate(serverTransaction, serverMutators, urlParams, payload));
+  return new Response(JSON.stringify(result), { status: 200, headers: { "content-type": "application/json" } });
 }
 ```
 

--- a/src/internal/server-synchronization-context.ts
+++ b/src/internal/server-synchronization-context.ts
@@ -1,64 +1,57 @@
-import * as Context from "effect/Context";
+import type * as Context from "effect/Context";
 import * as Effect from "effect/Effect";
-import * as Layer from "effect/Layer";
 import * as SynchronizedRef from "effect/SynchronizedRef";
 import { MultipleTransactionsError, NoTransactionError } from "./server.js";
-import { prefixId } from "./utils.js";
 
-export class ServerSynchronizationContext extends Context.Service<ServerSynchronizationContext>()(
-  prefixId("ServerSynchronizationContext"),
-  {
-    make: Effect.gen(function* () {
-      return {
-        wasTransactionExecuted: yield* SynchronizedRef.make(false),
-      };
-    }),
-  },
-) {}
+// The per-mutation synchronization state. It lives on the server-transaction `Mutation` service (rather
+// than a dedicated service), so `guard`/`finalize` are parameterized by the tag that carries it.
+export type Synchronization = { readonly executed: SynchronizedRef.SynchronizedRef<boolean> };
 
-export const layer: Layer.Layer<ServerSynchronizationContext> = Layer.effect(ServerSynchronizationContext)(
-  ServerSynchronizationContext.make,
-);
-
-// Ensures that only one transaction is executed at a time and checks that another transaction wasn't already executed.
-export const guard = <A, E, R>(effect: Effect.Effect<A, E, R>) =>
-  Effect.gen(function* () {
-    const ctx = yield* ServerSynchronizationContext;
-    return yield* SynchronizedRef.modifyEffect(
-      ctx.wasTransactionExecuted,
-      Effect.fn(function* (wasTransactionExecuted) {
-        if (wasTransactionExecuted) {
-          return yield* new MultipleTransactionsError();
-        }
-        const result = yield* effect;
-        return [result, true];
-      }),
-    );
-  });
-
-export const finalize = <A, E, R>(effect: Effect.Effect<A, E, R>) =>
-  Effect.gen(function* () {
-    const { wasTransactionExecuted } = yield* ServerSynchronizationContext;
-
-    return yield* effect.pipe(
-      // Case #2 "One transaction then fail"
-      // If the transaction was executed successfully, swallow the error and just log it, otherwise re-throw it
-      Effect.catchCause(
-        Effect.fn(function* (e) {
-          if (yield* SynchronizedRef.get(wasTransactionExecuted)) {
-            return yield* Effect.logError("Error occurred after transaction execution completed", e);
+// Ensures that at most one transaction is executed per mutation, and records that one committed.
+export const guard =
+  <I, V extends Synchronization>(tag: Context.Key<I, V>) =>
+  <A, E, R>(effect: Effect.Effect<A, E, R>) =>
+    Effect.gen(function* () {
+      const { executed } = yield* tag;
+      return yield* SynchronizedRef.modifyEffect(
+        executed,
+        Effect.fn(function* (wasExecuted) {
+          if (wasExecuted) {
+            return yield* new MultipleTransactionsError();
           }
-          return yield* Effect.failCause(e);
+          const result = yield* effect;
+          return [result, true];
         }),
-      ),
-      // Case #4 "Zero transactions then succeed"
-      // Check that the transaction was executed during the mutation
-      Effect.tap(
-        Effect.gen(function* () {
-          if (!(yield* SynchronizedRef.get(wasTransactionExecuted))) {
-            return yield* new NoTransactionError();
-          }
-        }),
-      ),
-    );
-  });
+      );
+    });
+
+// Enforces that a mutation runs at least one transaction, and that an error occurring AFTER a committed
+// transaction is swallowed (the DB state already changed, so the push response must report success).
+export const finalize =
+  <I, V extends Synchronization>(tag: Context.Key<I, V>) =>
+  <A, E, R>(effect: Effect.Effect<A, E, R>) =>
+    Effect.gen(function* () {
+      const { executed } = yield* tag;
+
+      return yield* effect.pipe(
+        // Case #2 "One transaction then fail"
+        // If the transaction was executed successfully, swallow the error and just log it, otherwise re-throw it
+        Effect.catchCause(
+          Effect.fn(function* (e) {
+            if (yield* SynchronizedRef.get(executed)) {
+              return yield* Effect.logError("Error occurred after transaction execution completed", e);
+            }
+            return yield* Effect.failCause(e);
+          }),
+        ),
+        // Case #4 "Zero transactions then succeed"
+        // Check that the transaction was executed during the mutation
+        Effect.tap(
+          Effect.gen(function* () {
+            if (!(yield* SynchronizedRef.get(executed))) {
+              return yield* new NoTransactionError();
+            }
+          }),
+        ),
+      );
+    });

--- a/src/internal/server.test.ts
+++ b/src/internal/server.test.ts
@@ -1,32 +1,37 @@
 import { describe, it } from "@effect/vitest";
 import { assertExitFailure } from "@effect/vitest/utils";
 import * as Cause from "effect/Cause";
+import * as Context from "effect/Context";
 import * as Effect from "effect/Effect";
 import * as Exit from "effect/Exit";
+import * as Layer from "effect/Layer";
+import * as SynchronizedRef from "effect/SynchronizedRef";
 import { NoTransactionError } from "./server.js";
-import * as ServerSynchronizationContext from "./server-synchronization-context.js";
+import { finalize, guard } from "./server-synchronization-context.js";
 
-describe("ServerSynchronizationContext", () => {
-  it.effect("finalize should return NoTransactionError when called without guard", () =>
+// A minimal stand-in for the per-mutation `Mutation` service, carrying just the synchronization state
+// that `guard`/`finalize` read.
+class Sync extends Context.Service<Sync, { readonly executed: SynchronizedRef.SynchronizedRef<boolean> }>()(
+  "effect-zero/test/Sync",
+) {}
+const layer = Layer.effect(Sync)(
+  Effect.gen(function* () {
+    return { executed: yield* SynchronizedRef.make(false) };
+  }),
+);
+
+describe("synchronization", () => {
+  it.effect("finalize should return NoTransactionError when no transaction ran", () =>
     Effect.gen(function* () {
-      const result = yield* Effect.void.pipe(
-        ServerSynchronizationContext.finalize,
-        Effect.provide(ServerSynchronizationContext.layer),
-        Effect.exit,
-      );
+      const result = yield* Effect.void.pipe(finalize(Sync), Effect.provide(layer), Effect.exit);
       assertExitFailure(result, Cause.fail(new NoTransactionError()));
     }),
   );
 
   it.effect(
-    "finalize shouldn't return errors when called with guard",
+    "finalize shouldn't return errors when guarded by a transaction",
     Effect.fn(function* ({ expect }) {
-      const result = yield* Effect.void.pipe(
-        ServerSynchronizationContext.guard,
-        ServerSynchronizationContext.finalize,
-        Effect.provide(ServerSynchronizationContext.layer),
-        Effect.exit,
-      );
+      const result = yield* Effect.void.pipe(guard(Sync), finalize(Sync), Effect.provide(layer), Effect.exit);
       if (Exit.isFailure(result)) {
         expect.fail("Expected success", result.cause);
       }

--- a/src/internal/server.ts
+++ b/src/internal/server.ts
@@ -1,15 +1,8 @@
-import type { TransactionProviderInput } from "@rocicorp/zero/server";
 import { ApplicationError } from "@rocicorp/zero/server";
 import * as Cause from "effect/Cause";
-import * as Context from "effect/Context";
 import * as Data from "effect/Data";
 import * as Predicate from "effect/Predicate";
 import type * as Schema from "effect/Schema";
-import { prefixId } from "./utils.js";
-
-export class ServerTransactionInput extends Context.Service<ServerTransactionInput, TransactionProviderInput>()(
-  prefixId("ServerTransactionInput"),
-) {}
 
 export class NoTransactionError extends Data.TaggedError("NoTransactionError") {
   message = "No transaction detected in a mutation, a transaction is required.";

--- a/src/internal/server.ts
+++ b/src/internal/server.ts
@@ -1,7 +1,10 @@
 import type { TransactionProviderInput } from "@rocicorp/zero/server";
+import { ApplicationError } from "@rocicorp/zero/server";
+import * as Cause from "effect/Cause";
 import * as Context from "effect/Context";
 import * as Data from "effect/Data";
 import * as Predicate from "effect/Predicate";
+import type * as Schema from "effect/Schema";
 import { prefixId } from "./utils.js";
 
 export class ServerTransactionInput extends Context.Service<ServerTransactionInput, TransactionProviderInput>()(
@@ -13,32 +16,34 @@ export class NoTransactionError extends Data.TaggedError("NoTransactionError") {
 }
 export class MultipleTransactionsError extends Data.TaggedError("MultipleTransactionsError") {}
 
-const OutOfOrderMutationErrorTypeId = Symbol.for(prefixId("OutOfOrderMutationError"));
-export class OutOfOrderMutationError extends Data.TaggedError("OutOfOrderMutationError")<{
-  readonly clientID: string;
-  readonly receivedMutationID: number;
-  readonly lastMutationID: number | bigint;
-}> {
-  readonly [OutOfOrderMutationErrorTypeId] = OutOfOrderMutationErrorTypeId;
-  override get message() {
-    return `Client ${this.clientID} sent mutation ID ${this.receivedMutationID} but expected ${this.lastMutationID}`;
-  }
-  static is(e: unknown): e is OutOfOrderMutationError {
-    return Predicate.hasProperty(e, OutOfOrderMutationErrorTypeId);
-  }
-}
+export class MutatorNotFoundError extends Data.TaggedError("MutatorNotFoundError")<{
+  readonly name: string;
+}> {}
 
-const MutationAlreadyProcessedErrorTypeId = Symbol.for(prefixId("MutationAlreadyProcessedError"));
-export class MutationAlreadyProcessedError extends Data.TaggedError("MutationAlreadyProcessedError")<{
-  readonly clientID: string;
-  readonly received: number;
-  readonly actual: number | bigint;
-}> {
-  readonly [MutationAlreadyProcessedErrorTypeId] = MutationAlreadyProcessedErrorTypeId;
-  override get message() {
-    return `Ignoring mutation from ${this.clientID} with ID ${this.received} as it was already processed. Expected: ${this.actual}`;
+export class ServerArgsParseError extends Data.TaggedError("ServerArgsParseError")<{
+  readonly cause: Cause.Cause<Schema.SchemaError>;
+}> {}
+
+// Recursively unwrap Effect `cause` wrappers (e.g. ServerTransactionError) to find the root user
+// message, so a mutator failure surfaces the original error text rather than an empty wrapper message.
+const messageFromCause = (cause: Cause.Cause<unknown>): string => {
+  const error = Cause.squash(cause);
+  // Errors that originate from our own machinery (not the user's mutator) are reported generically.
+  if (error instanceof MutatorNotFoundError || error instanceof ServerArgsParseError) {
+    return "Internal error";
   }
-  static is(e: unknown): e is MutationAlreadyProcessedError {
-    return Predicate.hasProperty(e, MutationAlreadyProcessedErrorTypeId);
+  if (Predicate.hasProperty(error, "cause") && Cause.isCause(error.cause)) {
+    const inner = messageFromCause(error.cause);
+    if (inner) return inner;
   }
-}
+  if (error instanceof Error && error.message) return error.message;
+  return "Internal error";
+};
+
+// Convert an Effect failure cause into an upstream `ApplicationError`, which `handleMutateRequest`
+// recognizes (via `isApplicationError`) and turns into a per-mutation `{ error: "app", ... }` response.
+// `details` is set explicitly because upstream `makeAppErrorResponse` only emits `details` when truthy.
+export const toApplicationError = (cause: Cause.Cause<unknown>): ApplicationError => {
+  const message = messageFromCause(cause);
+  return new ApplicationError(message, { details: message, cause: Cause.squash(cause) });
+};

--- a/src/server-transaction.ts
+++ b/src/server-transaction.ts
@@ -8,8 +8,6 @@ import * as Effect from "effect/Effect";
 import * as Exit from "effect/Exit";
 import type { NodeInspectSymbol } from "effect/Inspectable";
 import * as Layer from "effect/Layer";
-import * as Option from "effect/Option";
-import * as Ref from "effect/Ref";
 import type * as Unify from "effect/Unify";
 import type * as ClientTransaction from "./client-transaction.js";
 import { toApplicationError } from "./internal/server.js";
@@ -29,20 +27,17 @@ export const make = <const Id extends string, TSchema extends ZeroSchema, TTrans
   clientTransaction: ClientTransaction.Context<TSchema>,
 ) => {
   type Database = ZQLDatabase<TSchema, TTransaction>;
-  // The per-mutation `MutationResponse` produced by the upstream `transact`.
-  type MutationResponse = Awaited<ReturnType<TransactFn<Database>>>;
 
   // The live Zero transaction, available only while a `transact` callback is executing.
   class Context extends Ctx.Service<Context, ZeroServerTransaction<TSchema, TTransaction>>()(
     `${id as string}/ServerTransactionContext` as const,
   ) {}
 
-  // The per-mutation channel between `handleMutate` and `execute`: the upstream `transact` to run the
-  // transaction with, and a slot where `execute` publishes the resulting `MutationResponse`.
-  class Mutation extends Ctx.Service<
-    Mutation,
-    { readonly transact: TransactFn<Database>; readonly response: Ref.Ref<Option.Option<MutationResponse>> }
-  >()(`${id as string}/ServerTransactionMutation` as const) {}
+  // The capability `execute` uses to run this mutation's transaction: the upstream `transact`, wrapped
+  // by `handleMutate` so the resulting `MutationResponse` is also captured for it to return.
+  class Mutation extends Ctx.Service<Mutation, TransactFn<Database>>()(
+    `${id as string}/ServerTransactionMutation` as const,
+  ) {}
 
   const use = <A>(
     fn: (
@@ -60,11 +55,11 @@ export const make = <const Id extends string, TSchema extends ZeroSchema, TTrans
 
   const execute = Effect.fn(function* <A, E, R>(effect: Effect.Effect<A, E, R>) {
     const ctx = yield* Effect.context<Exclude<R, (typeof clientTransaction.Context)["Identifier"] | Context>>();
-    const { transact, response: responseStore } = yield* Mutation;
+    const transact = yield* Mutation;
     // Bridges the inner effect's value/failure back out of the async `transact` callback to the mutator.
     const result = yield* Deferred.make<A, E | MutationShortCircuit>();
 
-    const response = yield* Effect.tryPromise({
+    yield* Effect.tryPromise({
       try: (signal) =>
         // The upstream `transact` opens the DB transaction, runs the last-mutation-id check
         // (throwing OutOfOrderMutation / already-processed itself), invokes this callback to perform
@@ -91,10 +86,9 @@ export const make = <const Id extends string, TSchema extends ZeroSchema, TTrans
         error instanceof OutOfOrderMutation ? error : new ExecuteTransactError({ cause: Cause.fail(error) }),
     });
 
-    yield* Ref.set(responseStore, Option.some(response));
     // If `transact` resolved without ever invoking our callback (e.g. an already-processed mutation,
     // whose last-mutation-id check fails before the callback runs), `result` was never completed.
-    // Fail it (a no-op when already done) so we surface the stashed response instead of hanging.
+    // Fail it (a no-op when already done) so `handleMutate` surfaces the captured response instead of hanging.
     yield* Deferred.fail(result, new MutationShortCircuit());
     return yield* Deferred.await(result);
   }, ServerSynchronizationContext.guard);

--- a/src/server-transaction.ts
+++ b/src/server-transaction.ts
@@ -3,7 +3,6 @@ import { OutOfOrderMutation, type TransactFn, type ZQLDatabase } from "@rocicorp
 import * as Cause from "effect/Cause";
 import * as Ctx from "effect/Context";
 import * as Data from "effect/Data";
-import * as Deferred from "effect/Deferred";
 import * as Effect from "effect/Effect";
 import * as Exit from "effect/Exit";
 import type { NodeInspectSymbol } from "effect/Inspectable";
@@ -56,8 +55,9 @@ export const make = <const Id extends string, TSchema extends ZeroSchema, TTrans
   const execute = Effect.fn(function* <A, E, R>(effect: Effect.Effect<A, E, R>) {
     const ctx = yield* Effect.context<Exclude<R, (typeof clientTransaction.Context)["Identifier"] | Context>>();
     const transact = yield* Mutation;
-    // Bridges the inner effect's value/failure back out of the async `transact` callback to the mutator.
-    const result = yield* Deferred.make<A, E | MutationShortCircuit>();
+    // Captures the inner effect's Exit out of the async `transact` callback. Upstream awaits the callback
+    // before `transact` resolves, so a plain closure variable suffices — no Deferred rendezvous needed.
+    let exit: Exit.Exit<A, E> | undefined;
 
     yield* Effect.tryPromise({
       try: (signal) =>
@@ -66,14 +66,13 @@ export const make = <const Id extends string, TSchema extends ZeroSchema, TTrans
         // the writes, and resolves with the resulting MutationResponse (or with an app-error response
         // if this callback throws an ApplicationError).
         transact(async (transaction) => {
-          const exit = await effect.pipe(
+          exit = await effect.pipe(
             Effect.provide([
               Layer.succeed(Context, transaction),
               Layer.succeed(clientTransaction.Context, transaction),
             ]),
             (eff) => Effect.runPromiseExitWith(ctx)(eff, { signal }),
           );
-          Deferred.doneUnsafe(result, exit);
           if (Exit.isFailure(exit)) {
             // Throw an upstream ApplicationError so `transact` retries the transaction without the
             // mutator and writes the app-error result, then resolves with that response.
@@ -87,10 +86,10 @@ export const make = <const Id extends string, TSchema extends ZeroSchema, TTrans
     });
 
     // If `transact` resolved without ever invoking our callback (e.g. an already-processed mutation,
-    // whose last-mutation-id check fails before the callback runs), `result` was never completed.
-    // Fail it (a no-op when already done) so `handleMutate` surfaces the captured response instead of hanging.
-    yield* Deferred.fail(result, new MutationShortCircuit());
-    return yield* Deferred.await(result);
+    // whose last-mutation-id check fails before the callback runs), `exit` is unset — short-circuit so
+    // `handleMutate` surfaces the captured response instead of hanging.
+    if (exit === undefined) return yield* new MutationShortCircuit();
+    return yield* exit;
   }, ServerSynchronizationContext.guard);
 
   return { Context, Mutation, database, use, execute };

--- a/src/server-transaction.ts
+++ b/src/server-transaction.ts
@@ -1,5 +1,5 @@
 import type { Schema as ZeroSchema, ServerTransaction as ZeroServerTransaction } from "@rocicorp/zero";
-import type { TransactionProviderHooks, ZQLDatabase } from "@rocicorp/zero/server";
+import { OutOfOrderMutation, type TransactFn, type ZQLDatabase } from "@rocicorp/zero/server";
 import * as Cause from "effect/Cause";
 import * as Ctx from "effect/Context";
 import * as Data from "effect/Data";
@@ -8,14 +8,14 @@ import * as Effect from "effect/Effect";
 import * as Exit from "effect/Exit";
 import type { NodeInspectSymbol } from "effect/Inspectable";
 import * as Layer from "effect/Layer";
-import * as Predicate from "effect/Predicate";
+import * as Option from "effect/Option";
+import * as Ref from "effect/Ref";
 import type * as Unify from "effect/Unify";
 import type * as ClientTransaction from "./client-transaction.js";
-import { MutationAlreadyProcessedError, OutOfOrderMutationError, ServerTransactionInput } from "./internal/server.js";
+import { ServerTransactionInput, toApplicationError } from "./internal/server.js";
 import * as ServerSynchronizationContext from "./internal/server-synchronization-context.js";
-import { prefixId } from "./internal/utils.js";
 
-// Updated to: https://github.com/rocicorp/mono/blob/3082c9fa061891067b4bd7dc9fe74f798270d8d7/packages/zero-server/src/push-processor.ts
+// Updated to: https://github.com/rocicorp/mono/blob/3082c9fa061891067b4bd7dc9fe74f798270d8d7/packages/zero-server/src/process-mutations.ts
 
 type _NodeInspectSymbol = NodeInspectSymbol;
 type _Unify = Unify.typeSymbol | Unify.unifySymbol | Unify.ignoreSymbol;
@@ -28,10 +28,24 @@ export const make = <const Id extends string, TSchema extends ZeroSchema, TTrans
   database: ZQLDatabase<TSchema, TTransaction>,
   clientTransaction: ClientTransaction.Context<TSchema>,
 ) => {
-  class Context extends Ctx.Service<
-    Context,
-    { transaction: ZeroServerTransaction<TSchema, TTransaction>; transactionHooks: TransactionProviderHooks }
-  >()(`${id as string}/ServerTransactionContext` as const) {}
+  type Database = ZQLDatabase<TSchema, TTransaction>;
+  // The per-mutation `MutationResponse` produced by the upstream `transact`.
+  type MutationResponse = Awaited<ReturnType<TransactFn<Database>>>;
+
+  class Context extends Ctx.Service<Context, { transaction: ZeroServerTransaction<TSchema, TTransaction> }>()(
+    `${id as string}/ServerTransactionContext` as const,
+  ) {}
+
+  // The upstream `transact` for the mutation currently being processed, supplied per-mutation by `handleMutate`.
+  class Transact extends Ctx.Service<Transact, TransactFn<Database>>()(
+    `${id as string}/ServerTransactionTransact` as const,
+  ) {}
+
+  // A per-mutation slot where `execute` publishes the `MutationResponse` it got back from `transact`,
+  // so `handleMutate`'s callback can return it.
+  class ResponseStore extends Ctx.Service<ResponseStore, Ref.Ref<Option.Option<MutationResponse>>>()(
+    `${id as string}/ServerTransactionResponseStore` as const,
+  ) {}
 
   const use = <A>(
     fn: (
@@ -48,91 +62,56 @@ export const make = <const Id extends string, TSchema extends ZeroSchema, TTrans
     });
 
   const execute = Effect.fn(function* <A, E, R>(effect: Effect.Effect<A, E, R>) {
-    const ctx = yield* Effect.context<
-      ServerTransactionInput | Exclude<R, (typeof clientTransaction.Context)["Identifier"] | Context>
-    >();
-    const result = yield* Deferred.make<A, E | Effect.Error<typeof checkAndIncrementLastMutationId>>();
+    const ctx = yield* Effect.context<Exclude<R, (typeof clientTransaction.Context)["Identifier"] | Context>>();
+    const transact = yield* Transact;
+    const responseStore = yield* ResponseStore;
+    // Bridges the inner effect's value/failure back out of the async `transact` callback to the mutator.
+    const result = yield* Deferred.make<A, E | MutationShortCircuit>();
 
-    const transactionInput = yield* ServerTransactionInput;
-    yield* Effect.tryPromise({
+    const response = yield* Effect.tryPromise({
       try: (signal) =>
-        database.transaction(async (transaction, transactionHooks) => {
-          const exit = await Effect.flatMap(checkAndIncrementLastMutationId, () => effect).pipe(
+        // The upstream `transact` opens the DB transaction, runs the last-mutation-id check
+        // (throwing OutOfOrderMutation / already-processed itself), invokes this callback to perform
+        // the writes, and resolves with the resulting MutationResponse (or with an app-error response
+        // if this callback throws an ApplicationError).
+        transact(async (transaction) => {
+          const exit = await effect.pipe(
             Effect.provide([
-              Layer.succeed(Context, { transaction, transactionHooks }),
+              Layer.succeed(Context, { transaction }),
               Layer.succeed(clientTransaction.Context, transaction),
             ]),
-            (effect) => Effect.runPromiseExitWith(ctx)(effect, { signal }),
+            (eff) => Effect.runPromiseExitWith(ctx)(eff, { signal }),
           );
           Deferred.doneUnsafe(result, exit);
           if (Exit.isFailure(exit)) {
-            // This error's purpose is to differentiate between "external" errors
-            // that originate from the user-defined mutator code and "internal" errors
-            // that originate from our own code and the Zero API.
-            // Both types are caught in the "catch" block below, but at this point we only need to handle
-            // the "internal" errors wrapping them in a `ZeroDatabaseError`, because "external" errors
-            // are already covered by passing the Exit result to the Deferred, which is why
-            // we have the ServerTransactionUserError silenced below in the pipe.
-            throw new ServerTransactionUserError();
+            // Throw an upstream ApplicationError so `transact` retries the transaction without the
+            // mutator and writes the app-error result, then resolves with that response.
+            throw toApplicationError(exit.cause);
           }
-          return exit.value;
-        }, transactionInput),
-      catch: (error) => {
-        if (ServerTransactionUserError.is(error)) {
-          return error;
-        }
-        // This is for errors that occur when calling `database.transaction` despite the provided `effect` succeeding.
-        // This can be caused by e.g. the database connection timing out or other database-related issues.
-        return new ZeroDatabaseError({ cause: Cause.fail(error) });
-      },
-    }).pipe(Effect.catchTag("ServerTransactionUserError", () => Effect.void));
+        }),
+      // OutOfOrderMutation must escape unconverted so it reaches handleMutateRequest's top-level
+      // handler (which produces a PushFailed response); everything else is an internal DB error.
+      catch: (error) =>
+        error instanceof OutOfOrderMutation ? error : new ExecuteTransactError({ cause: Cause.fail(error) }),
+    });
 
+    yield* Ref.set(responseStore, Option.some(response));
+    // If `transact` resolved without ever invoking our callback (e.g. an already-processed mutation,
+    // whose last-mutation-id check fails before the callback runs), `result` was never completed.
+    // Fail it (a no-op when already done) so we surface the stashed response instead of hanging.
+    yield* Deferred.fail(result, new MutationShortCircuit());
     return yield* Deferred.await(result);
   }, ServerSynchronizationContext.guard);
 
-  const checkAndIncrementLastMutationId = Effect.gen(function* () {
-    const { transactionHooks } = yield* Context;
-    const { clientID, mutationID: receivedMutationID } = yield* ServerTransactionInput;
-
-    const { lastMutationID } = yield* Effect.tryPromise({
-      try: () => transactionHooks.updateClientMutationID(),
-      catch: (error) => new UpdateClientMutationIdError({ cause: Cause.fail(error) }),
-    });
-
-    if (receivedMutationID < lastMutationID) {
-      return yield* new MutationAlreadyProcessedError({
-        clientID,
-        received: receivedMutationID,
-        actual: lastMutationID,
-      });
-    }
-    if (receivedMutationID > lastMutationID) {
-      return yield* new OutOfOrderMutationError({
-        clientID,
-        receivedMutationID,
-        lastMutationID,
-      });
-    }
-  });
-
-  return { Context, use, execute };
+  return { Context, Transact, ResponseStore, database, use, execute };
 };
 
 class ServerTransactionError extends Data.TaggedError("ServerTransactionError")<{
   readonly cause: Cause.Cause<unknown>;
 }> {}
 
-class UpdateClientMutationIdError extends Data.TaggedError("UpdateClientMutationIdError")<{
-  readonly cause: Cause.Cause<unknown>;
-}> {}
-class ZeroDatabaseError extends Data.TaggedError("ZeroDatabaseError")<{
+class ExecuteTransactError extends Data.TaggedError("ExecuteTransactError")<{
   readonly cause: Cause.Cause<unknown>;
 }> {}
 
-const ServerTransactionUserErrorTypeId = Symbol.for(prefixId("ServerTransactionUserError"));
-class ServerTransactionUserError extends Data.TaggedError("ServerTransactionUserError") {
-  readonly [ServerTransactionUserErrorTypeId] = ServerTransactionUserErrorTypeId;
-  static is(e: unknown): e is ServerTransactionUserError {
-    return Predicate.hasProperty(e, ServerTransactionUserErrorTypeId);
-  }
-}
+class MutationShortCircuit extends Data.TaggedError("MutationShortCircuit") {}

--- a/src/server-transaction.ts
+++ b/src/server-transaction.ts
@@ -7,10 +7,11 @@ import * as Effect from "effect/Effect";
 import * as Exit from "effect/Exit";
 import type { NodeInspectSymbol } from "effect/Inspectable";
 import * as Layer from "effect/Layer";
+import type * as SynchronizedRef from "effect/SynchronizedRef";
 import type * as Unify from "effect/Unify";
 import type * as ClientTransaction from "./client-transaction.js";
 import { toApplicationError } from "./internal/server.js";
-import * as ServerSynchronizationContext from "./internal/server-synchronization-context.js";
+import { finalize, guard } from "./internal/server-synchronization-context.js";
 
 // Updated to: https://github.com/rocicorp/mono/blob/3082c9fa061891067b4bd7dc9fe74f798270d8d7/packages/zero-server/src/process-mutations.ts
 
@@ -32,11 +33,13 @@ export const make = <const Id extends string, TSchema extends ZeroSchema, TTrans
     `${id as string}/ServerTransactionContext` as const,
   ) {}
 
-  // The capability `execute` uses to run this mutation's transaction: the upstream `transact`, wrapped
-  // by `handleMutate` so the resulting `MutationResponse` is also captured for it to return.
-  class Mutation extends Ctx.Service<Mutation, TransactFn<Database>>()(
-    `${id as string}/ServerTransactionMutation` as const,
-  ) {}
+  // The per-mutation channel `execute` and `finalize` use: the upstream `transact` (wrapped by
+  // `handleMutate` to capture its response) plus the synchronization flag tracking whether a
+  // transaction has committed (formerly a separate ServerSynchronizationContext service).
+  class Mutation extends Ctx.Service<
+    Mutation,
+    { readonly transact: TransactFn<Database>; readonly executed: SynchronizedRef.SynchronizedRef<boolean> }
+  >()(`${id as string}/ServerTransactionMutation` as const) {}
 
   const use = <A>(
     fn: (
@@ -54,7 +57,7 @@ export const make = <const Id extends string, TSchema extends ZeroSchema, TTrans
 
   const execute = Effect.fn(function* <A, E, R>(effect: Effect.Effect<A, E, R>) {
     const ctx = yield* Effect.context<Exclude<R, (typeof clientTransaction.Context)["Identifier"] | Context>>();
-    const transact = yield* Mutation;
+    const { transact } = yield* Mutation;
     // Captures the inner effect's Exit out of the async `transact` callback. Upstream awaits the callback
     // before `transact` resolves, so a plain closure variable suffices — no Deferred rendezvous needed.
     let exit: Exit.Exit<A, E> | undefined;
@@ -90,9 +93,9 @@ export const make = <const Id extends string, TSchema extends ZeroSchema, TTrans
     // `handleMutate` surfaces the captured response instead of hanging.
     if (exit === undefined) return yield* new MutationShortCircuit();
     return yield* exit;
-  }, ServerSynchronizationContext.guard);
+  }, guard(Mutation));
 
-  return { Context, Mutation, database, use, execute };
+  return { Context, Mutation, database, use, execute, finalize: finalize(Mutation) };
 };
 
 class ServerTransactionError extends Data.TaggedError("ServerTransactionError")<{

--- a/src/server-transaction.ts
+++ b/src/server-transaction.ts
@@ -12,7 +12,7 @@ import * as Option from "effect/Option";
 import * as Ref from "effect/Ref";
 import type * as Unify from "effect/Unify";
 import type * as ClientTransaction from "./client-transaction.js";
-import { ServerTransactionInput, toApplicationError } from "./internal/server.js";
+import { toApplicationError } from "./internal/server.js";
 import * as ServerSynchronizationContext from "./internal/server-synchronization-context.js";
 
 // Updated to: https://github.com/rocicorp/mono/blob/3082c9fa061891067b4bd7dc9fe74f798270d8d7/packages/zero-server/src/process-mutations.ts
@@ -32,20 +32,17 @@ export const make = <const Id extends string, TSchema extends ZeroSchema, TTrans
   // The per-mutation `MutationResponse` produced by the upstream `transact`.
   type MutationResponse = Awaited<ReturnType<TransactFn<Database>>>;
 
-  class Context extends Ctx.Service<Context, { transaction: ZeroServerTransaction<TSchema, TTransaction> }>()(
+  // The live Zero transaction, available only while a `transact` callback is executing.
+  class Context extends Ctx.Service<Context, ZeroServerTransaction<TSchema, TTransaction>>()(
     `${id as string}/ServerTransactionContext` as const,
   ) {}
 
-  // The upstream `transact` for the mutation currently being processed, supplied per-mutation by `handleMutate`.
-  class Transact extends Ctx.Service<Transact, TransactFn<Database>>()(
-    `${id as string}/ServerTransactionTransact` as const,
-  ) {}
-
-  // A per-mutation slot where `execute` publishes the `MutationResponse` it got back from `transact`,
-  // so `handleMutate`'s callback can return it.
-  class ResponseStore extends Ctx.Service<ResponseStore, Ref.Ref<Option.Option<MutationResponse>>>()(
-    `${id as string}/ServerTransactionResponseStore` as const,
-  ) {}
+  // The per-mutation channel between `handleMutate` and `execute`: the upstream `transact` to run the
+  // transaction with, and a slot where `execute` publishes the resulting `MutationResponse`.
+  class Mutation extends Ctx.Service<
+    Mutation,
+    { readonly transact: TransactFn<Database>; readonly response: Ref.Ref<Option.Option<MutationResponse>> }
+  >()(`${id as string}/ServerTransactionMutation` as const) {}
 
   const use = <A>(
     fn: (
@@ -54,17 +51,16 @@ export const make = <const Id extends string, TSchema extends ZeroSchema, TTrans
     ) => PromiseLike<A>,
   ) =>
     Effect.gen(function* () {
-      const ctx = yield* Context;
+      const transaction = yield* Context;
       return yield* Effect.tryPromise({
-        try: (signal) => fn(ctx.transaction, { signal }),
+        try: (signal) => fn(transaction, { signal }),
         catch: (error) => new ServerTransactionError({ cause: Cause.fail(error) }),
       });
     });
 
   const execute = Effect.fn(function* <A, E, R>(effect: Effect.Effect<A, E, R>) {
     const ctx = yield* Effect.context<Exclude<R, (typeof clientTransaction.Context)["Identifier"] | Context>>();
-    const transact = yield* Transact;
-    const responseStore = yield* ResponseStore;
+    const { transact, response: responseStore } = yield* Mutation;
     // Bridges the inner effect's value/failure back out of the async `transact` callback to the mutator.
     const result = yield* Deferred.make<A, E | MutationShortCircuit>();
 
@@ -77,7 +73,7 @@ export const make = <const Id extends string, TSchema extends ZeroSchema, TTrans
         transact(async (transaction) => {
           const exit = await effect.pipe(
             Effect.provide([
-              Layer.succeed(Context, { transaction }),
+              Layer.succeed(Context, transaction),
               Layer.succeed(clientTransaction.Context, transaction),
             ]),
             (eff) => Effect.runPromiseExitWith(ctx)(eff, { signal }),
@@ -103,7 +99,7 @@ export const make = <const Id extends string, TSchema extends ZeroSchema, TTrans
     return yield* Deferred.await(result);
   }, ServerSynchronizationContext.guard);
 
-  return { Context, Transact, ResponseStore, database, use, execute };
+  return { Context, Mutation, database, use, execute };
 };
 
 class ServerTransactionError extends Data.TaggedError("ServerTransactionError")<{

--- a/src/server.ts
+++ b/src/server.ts
@@ -16,12 +16,7 @@ import * as Ref from "effect/Ref";
 import * as Schema from "effect/Schema";
 import * as Str from "effect/String";
 import type * as Unify from "effect/Unify";
-import {
-  MutatorNotFoundError,
-  ServerArgsParseError,
-  ServerTransactionInput,
-  toApplicationError,
-} from "./internal/server.js";
+import { MutatorNotFoundError, ServerArgsParseError, toApplicationError } from "./internal/server.js";
 import * as ServerSynchronizationContext from "./internal/server-synchronization-context.js";
 import { normalizeArgs, prefixId } from "./internal/utils.js";
 import * as Mutators from "./mutators.js";
@@ -52,17 +47,14 @@ export const handleMutate = Effect.fn(function* <
   request: Types.PushBody,
 ) {
   // Capture only the mutators' genuinely external requirements: the per-mutation plumbing services
-  // (the upstream `transact`, the response slot, the mutation input and the synchronization context)
-  // are provided per-mutation below, so they must not leak into `handleMutate`'s own requirements.
-  // The exclusion set is the exact union provided below, so `Effect.provide(ctx)` discharges the rest.
+  // (the `Mutation` channel and the synchronization context) are provided per-mutation below, so they
+  // must not leak into `handleMutate`'s own requirements. The exclusion set is the exact union provided
+  // below, so `Effect.provide(ctx)` discharges the rest.
   const ctx =
     yield* Effect.context<
       Exclude<
         Mutators.ExtractMutatorsRequirements<TMutators>,
-        | (typeof transaction.Transact)["Identifier"]
-        | (typeof transaction.ResponseStore)["Identifier"]
-        | ServerTransactionInput
-        | ServerSynchronizationContext.ServerSynchronizationContext
+        (typeof transaction.Mutation)["Identifier"] | ServerSynchronizationContext.ServerSynchronizationContext
       >
     >();
 
@@ -79,17 +71,10 @@ export const handleMutate = Effect.fn(function* <
               mutation,
             ).pipe(
               Effect.flatMap(({ mutator, args }) => mutator(args).pipe(ServerSynchronizationContext.finalize)),
-              // Provide all per-mutation plumbing in a single layer so the residual requirement is a
+              // Provide the per-mutation plumbing in a single layer so the residual requirement is a
               // single `Exclude<..., union>` that exactly matches `ctx` and cancels to `never`.
               Effect.provide([
-                Layer.succeed(transaction.Transact, transact),
-                Layer.succeed(transaction.ResponseStore, responseStore),
-                Layer.succeed(ServerTransactionInput, {
-                  clientID: mutation.clientID,
-                  mutationID: mutation.id,
-                  clientGroupID: request.clientGroupID,
-                  upstreamSchema: params.schema,
-                }),
+                Layer.succeed(transaction.Mutation, { transact, response: responseStore }),
                 ServerSynchronizationContext.layer,
               ]),
               Effect.exit,

--- a/src/server.ts
+++ b/src/server.ts
@@ -7,16 +7,15 @@ import * as Effect from "effect/Effect";
 import * as Exit from "effect/Exit";
 import * as Fn from "effect/Function";
 import type { NodeInspectSymbol } from "effect/Inspectable";
-import * as Layer from "effect/Layer";
 import * as Match from "effect/Match";
 import * as Option from "effect/Option";
 import * as Predicate from "effect/Predicate";
 import * as Rec from "effect/Record";
 import * as Schema from "effect/Schema";
 import * as Str from "effect/String";
+import * as SynchronizedRef from "effect/SynchronizedRef";
 import type * as Unify from "effect/Unify";
 import { MutatorNotFoundError, ServerArgsParseError, toApplicationError } from "./internal/server.js";
-import * as ServerSynchronizationContext from "./internal/server-synchronization-context.js";
 import { normalizeArgs, prefixId } from "./internal/utils.js";
 import * as Mutators from "./mutators.js";
 import { type MakeQueryResult, QueryNameSymbol, RunQuerySymbol } from "./query.js";
@@ -45,16 +44,12 @@ export const handleMutate = Effect.fn(function* <
   params: Types.PushParams,
   request: Types.PushBody,
 ) {
-  // Capture only the mutators' genuinely external requirements: the per-mutation plumbing services
-  // (the `Mutation` channel and the synchronization context) are provided per-mutation below, so they
-  // must not leak into `handleMutate`'s own requirements. The exclusion set is the exact union provided
-  // below, so `Effect.provide(ctx)` discharges the rest.
+  // Capture only the mutators' genuinely external requirements: the per-mutation `Mutation` service is
+  // provided per-mutation below, so it must not leak into `handleMutate`'s own requirements. The
+  // exclusion exactly matches what is provided, so `Effect.provide(ctx)` discharges the rest.
   const ctx =
     yield* Effect.context<
-      Exclude<
-        Mutators.ExtractMutatorsRequirements<TMutators>,
-        (typeof transaction.Mutation)["Identifier"] | ServerSynchronizationContext.ServerSynchronizationContext
-      >
+      Exclude<Mutators.ExtractMutatorsRequirements<TMutators>, (typeof transaction.Mutation)["Identifier"]>
     >();
 
   return yield* Effect.tryPromise({
@@ -72,14 +67,16 @@ export const handleMutate = Effect.fn(function* <
               return mutationResponse;
             });
 
-          const program = lookupAndDecode<Mutators.ExtractMutatorsRequirements<TMutators>>(mutators, mutation).pipe(
-            Effect.flatMap(({ mutator, args }) => mutator(args).pipe(ServerSynchronizationContext.finalize)),
-            // Provide the per-mutation plumbing in a single layer so the residual requirement is a
-            // single `Exclude<..., union>` that exactly matches `ctx` and cancels to `never`.
-            Effect.provide([Layer.succeed(transaction.Mutation, runTransact), ServerSynchronizationContext.layer]),
-            Effect.exit,
-            Effect.provide(ctx),
-          );
+          const program = Effect.gen(function* () {
+            const executed = yield* SynchronizedRef.make(false);
+            return yield* lookupAndDecode<Mutators.ExtractMutatorsRequirements<TMutators>>(mutators, mutation).pipe(
+              Effect.flatMap(({ mutator, args }) => transaction.finalize(mutator(args))),
+              // Provide the single per-mutation `Mutation` service (wrapped transact + sync flag) so the
+              // residual requirement is `Exclude<..., Mutation>`, which exactly matches `ctx`.
+              Effect.provideService(transaction.Mutation, { transact: runTransact, executed }),
+              Effect.exit,
+            );
+          }).pipe(Effect.provide(ctx));
 
           return Effect.runPromise(program).then((exit) => {
             // A transaction ran: return its captured response (success, app error, or already-processed).

--- a/src/server.ts
+++ b/src/server.ts
@@ -12,7 +12,6 @@ import * as Match from "effect/Match";
 import * as Option from "effect/Option";
 import * as Predicate from "effect/Predicate";
 import * as Rec from "effect/Record";
-import * as Ref from "effect/Ref";
 import * as Schema from "effect/Schema";
 import * as Str from "effect/String";
 import type * as Unify from "effect/Unify";
@@ -63,28 +62,27 @@ export const handleMutate = Effect.fn(function* <
       handleMutateRequest(
         transaction.database,
         (transact, mutation) => {
-          const program = Effect.gen(function* () {
-            const responseStore = yield* Ref.make(Option.none<Awaited<ReturnType<typeof transact>>>());
+          // Wrap the upstream `transact` so this mutation's `MutationResponse` is captured for us to
+          // return. `execute` only ever sees this single wrapped function (the `Mutation` service) —
+          // it does not deal with the response slot.
+          let response = Option.none<Awaited<ReturnType<typeof transact>>>();
+          const runTransact: typeof transact = (callback) =>
+            transact(callback).then((mutationResponse) => {
+              response = Option.some(mutationResponse);
+              return mutationResponse;
+            });
 
-            const exit = yield* lookupAndDecode<Mutators.ExtractMutatorsRequirements<TMutators>>(
-              mutators,
-              mutation,
-            ).pipe(
-              Effect.flatMap(({ mutator, args }) => mutator(args).pipe(ServerSynchronizationContext.finalize)),
-              // Provide the per-mutation plumbing in a single layer so the residual requirement is a
-              // single `Exclude<..., union>` that exactly matches `ctx` and cancels to `never`.
-              Effect.provide([
-                Layer.succeed(transaction.Mutation, { transact, response: responseStore }),
-                ServerSynchronizationContext.layer,
-              ]),
-              Effect.exit,
-            );
+          const program = lookupAndDecode<Mutators.ExtractMutatorsRequirements<TMutators>>(mutators, mutation).pipe(
+            Effect.flatMap(({ mutator, args }) => mutator(args).pipe(ServerSynchronizationContext.finalize)),
+            // Provide the per-mutation plumbing in a single layer so the residual requirement is a
+            // single `Exclude<..., union>` that exactly matches `ctx` and cancels to `never`.
+            Effect.provide([Layer.succeed(transaction.Mutation, runTransact), ServerSynchronizationContext.layer]),
+            Effect.exit,
+            Effect.provide(ctx),
+          );
 
-            return { exit, response: yield* Ref.get(responseStore) };
-          }).pipe(Effect.provide(ctx));
-
-          return Effect.runPromise(program).then(({ exit, response }) => {
-            // A transaction ran: return its response (success, app error, or already-processed).
+          return Effect.runPromise(program).then((exit) => {
+            // A transaction ran: return its captured response (success, app error, or already-processed).
             if (Option.isSome(response)) return response.value;
             // No transaction ran: a pre-transaction failure (or NoTransactionError).
             const cause = Exit.isFailure(exit) ? exit.cause : Cause.empty;

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,5 +1,5 @@
 import type { ReadonlyJSONValue, Schema as ZeroSchema } from "@rocicorp/zero";
-import { handleQueryRequest } from "@rocicorp/zero/server";
+import { handleMutateRequest, handleQueryRequest, OutOfOrderMutation } from "@rocicorp/zero/server";
 import * as Arr from "effect/Array";
 import * as Cause from "effect/Cause";
 import * as Data from "effect/Data";
@@ -7,21 +7,27 @@ import * as Effect from "effect/Effect";
 import * as Exit from "effect/Exit";
 import * as Fn from "effect/Function";
 import type { NodeInspectSymbol } from "effect/Inspectable";
+import * as Layer from "effect/Layer";
 import * as Match from "effect/Match";
 import * as Option from "effect/Option";
 import * as Predicate from "effect/Predicate";
 import * as Rec from "effect/Record";
+import * as Ref from "effect/Ref";
 import * as Schema from "effect/Schema";
-import * as Stream from "effect/Stream";
 import * as Str from "effect/String";
 import type * as Unify from "effect/Unify";
-import { MutationAlreadyProcessedError, OutOfOrderMutationError, ServerTransactionInput } from "./internal/server.js";
+import {
+  MutatorNotFoundError,
+  ServerArgsParseError,
+  ServerTransactionInput,
+  toApplicationError,
+} from "./internal/server.js";
 import * as ServerSynchronizationContext from "./internal/server-synchronization-context.js";
 import { normalizeArgs, prefixId } from "./internal/utils.js";
 import * as Mutators from "./mutators.js";
 import { type MakeQueryResult, QueryNameSymbol, RunQuerySymbol } from "./query.js";
 import type * as ServerTransaction from "./server-transaction.js";
-import * as Types from "./types/push.js";
+import type * as Types from "./types/push.js";
 import type { TransformRequestMessage } from "./types/queries.js";
 
 // Updated to:
@@ -31,7 +37,11 @@ import type { TransformRequestMessage } from "./types/queries.js";
 type _NodeInspectSymbol = NodeInspectSymbol;
 type _Unify = Unify.typeSymbol | Unify.unifySymbol | Unify.ignoreSymbol;
 
-export const processPush = Effect.fn(function* <
+// A thin, Effect-ful wrapper around the upstream `handleMutateRequest`. It mirrors `handleQuery`:
+// upstream owns the per-mutation loop, last-mutation-id ordering, app-error responses and out-of-order
+// handling; we only resolve+run the matching Effect mutator for each mutation. The mutator drives the
+// actual transaction through `serverTransaction.execute`, which uses the upstream `transact` callback.
+export const handleMutate = Effect.fn(function* <
   TSchema extends ZeroSchema,
   TTransaction,
   TMutators extends Mutators.AnyMutators,
@@ -41,43 +51,78 @@ export const processPush = Effect.fn(function* <
   params: Types.PushParams,
   request: Types.PushBody,
 ) {
-  if (request.pushVersion !== 1) {
-    return { error: "unsupportedPushVersion" as const };
-  }
+  // Capture only the mutators' genuinely external requirements: the per-mutation plumbing services
+  // (the upstream `transact`, the response slot, the mutation input and the synchronization context)
+  // are provided per-mutation below, so they must not leak into `handleMutate`'s own requirements.
+  // The exclusion set is the exact union provided below, so `Effect.provide(ctx)` discharges the rest.
+  const ctx =
+    yield* Effect.context<
+      Exclude<
+        Mutators.ExtractMutatorsRequirements<TMutators>,
+        | (typeof transaction.Transact)["Identifier"]
+        | (typeof transaction.ResponseStore)["Identifier"]
+        | ServerTransactionInput
+        | ServerSynchronizationContext.ServerSynchronizationContext
+      >
+    >();
 
-  const responses = yield* Stream.fromIterable(request.mutations).pipe(
-    Stream.mapEffect(
-      Effect.fn(function* (mutation) {
-        if (mutation.type !== "custom") {
-          return yield* new CustomMutationExpectedError();
-        }
+  return yield* Effect.tryPromise({
+    try: () =>
+      handleMutateRequest(
+        transaction.database,
+        (transact, mutation) => {
+          const program = Effect.gen(function* () {
+            const responseStore = yield* Ref.make(Option.none<Awaited<ReturnType<typeof transact>>>());
 
-        return yield* processMutation<Mutators.ExtractMutatorsRequirements<TMutators>>(mutators, mutation).pipe(
-          Effect.catch((e) => processMutationError(transaction, e)),
-          Effect.map((result) =>
-            Types.MutationResponse.make({ id: { id: mutation.id, clientID: mutation.clientID }, result }),
-          ),
-          Effect.provideService(ServerTransactionInput, {
-            clientID: mutation.clientID,
-            mutationID: mutation.id,
-            clientGroupID: request.clientGroupID,
-            upstreamSchema: params.schema,
-          }),
-          Effect.provide(ServerSynchronizationContext.layer),
-        );
-      }),
-    ),
-    // We only stop processing if the mutation is out of order.
-    // If the mutation has already been processed or if it returns an application error,
-    // we continue processing the next mutation.
-    Stream.takeUntil(({ result }) => Predicate.hasProperty(result, "error") && result.error === "oooMutation"),
-    Stream.runCollect,
-  );
+            const exit = yield* lookupAndDecode<Mutators.ExtractMutatorsRequirements<TMutators>>(
+              mutators,
+              mutation,
+            ).pipe(
+              Effect.flatMap(({ mutator, args }) => mutator(args).pipe(ServerSynchronizationContext.finalize)),
+              // Provide all per-mutation plumbing in a single layer so the residual requirement is a
+              // single `Exclude<..., union>` that exactly matches `ctx` and cancels to `never`.
+              Effect.provide([
+                Layer.succeed(transaction.Transact, transact),
+                Layer.succeed(transaction.ResponseStore, responseStore),
+                Layer.succeed(ServerTransactionInput, {
+                  clientID: mutation.clientID,
+                  mutationID: mutation.id,
+                  clientGroupID: request.clientGroupID,
+                  upstreamSchema: params.schema,
+                }),
+                ServerSynchronizationContext.layer,
+              ]),
+              Effect.exit,
+            );
 
-  return { mutations: responses } satisfies Types.PushResponse;
+            return { exit, response: yield* Ref.get(responseStore) };
+          }).pipe(Effect.provide(ctx));
+
+          return Effect.runPromise(program).then(({ exit, response }) => {
+            // A transaction ran: return its response (success, app error, or already-processed).
+            if (Option.isSome(response)) return response.value;
+            // No transaction ran: a pre-transaction failure (or NoTransactionError).
+            const cause = Exit.isFailure(exit) ? exit.cause : Cause.empty;
+            const error = Cause.squash(cause);
+            // Out-of-order must reach handleMutateRequest's top-level handler (-> PushFailed), so it
+            // must NOT be converted into an application error.
+            if (error instanceof OutOfOrderMutation) throw error;
+            throw toApplicationError(cause);
+          });
+        },
+        params,
+        request as ReadonlyJSONValue,
+      ),
+    // Mirrors handleQuery's QueryRequestError: only genuine infra/defect rejections reach here.
+    // (Out-of-order resolves to a top-level PushFailed value, so it does not land in this catch.)
+    catch: (e) => new HandleMutateError({ cause: Cause.fail(e) }),
+  });
 });
 
-const processMutation = Effect.fn(function* <R>(mutators: Mutators.AnyMutators<R>, mutation: Types.Mutation) {
+const lookupAndDecode = Effect.fn(function* <R>(
+  mutators: Mutators.AnyMutators<R>,
+  mutation: { readonly name: string; readonly args: ReadonlyArray<ReadonlyJSONValue> },
+) {
   // Support both "namespace|name" and "namespace.name" formats, and single-segment names.
   const [namespace, name] = mutation.name.includes("|") ? Str.split(mutation.name, "|") : Str.split(mutation.name, ".");
 
@@ -99,86 +144,10 @@ const processMutation = Effect.fn(function* <R>(mutators: Mutators.AnyMutators<R
     normalizeArgs(mutation.args[0]),
   ).pipe(Effect.catchTag("SchemaError", (e) => Effect.fail(new ServerArgsParseError({ cause: Cause.fail(e) }))));
 
-  return yield* mutator(args).pipe(
-    ServerSynchronizationContext.finalize,
-    Effect.as<Types.MutationResult>({}),
-    Effect.catchIf(OutOfOrderMutationError.is, (e) =>
-      Effect.logError(e.message).pipe(
-        Effect.as({ error: "oooMutation", details: e.message } satisfies Types.ZeroError),
-      ),
-    ),
-    Effect.catchIf(MutationAlreadyProcessedError.is, (e) =>
-      Effect.logWarning(e.message).pipe(
-        Effect.as({ error: "alreadyProcessed", details: e.message } satisfies Types.ZeroError),
-      ),
-    ),
-    // Case #5 "Zero transactions then fail" / #6 "Fail before transaction"
-    // Catches all errors that are produced before the transaction is executed
-    Effect.catchCause((cause) => Effect.fail(new MutationUserError({ cause }))),
-  );
+  return { mutator, args };
 });
 
-const processMutationError = Effect.fn(function* <TSchema extends ZeroSchema, TTransaction>(
-  transaction: ServerTransaction.Context<TSchema, TTransaction>,
-  e: unknown,
-) {
-  const { clientID, mutationID } = yield* ServerTransactionInput;
-
-  yield* Effect.logError(`Unexpected error processing mutation ${mutationID} for client ${clientID}`, Cause.fail(e));
-
-  const errorMessage = Match.value(e).pipe(
-    Match.when(MutationUserError.is, (e) => e.message),
-    Match.orElse(() => "Internal error"),
-  );
-
-  const appError = {
-    error: "app",
-    details: errorMessage,
-  } satisfies Types.AppError;
-
-  yield* transaction
-    .execute(
-      Effect.gen(function* () {
-        const { transactionHooks } = yield* transaction.Context;
-        return yield* Effect.tryPromise({
-          try: () => transactionHooks.writeMutationResult({ id: { id: mutationID, clientID }, result: appError }),
-          catch: (error) => new WriteMutationResultError({ cause: Cause.fail(error) }),
-        });
-      }),
-    )
-    .pipe(Effect.catchCause(Effect.logError));
-
-  yield* Effect.logWarning(`Mutation ${mutationID} for client ${clientID} was retried after an error: ${e}`);
-
-  return appError;
-});
-
-class WriteMutationResultError extends Data.TaggedError("WriteMutationResultError")<{
-  readonly cause: Cause.Cause<unknown>;
-}> {}
-class CustomMutationExpectedError extends Data.TaggedError("CustomMutationExpectedError") {}
-class MutatorNotFoundError extends Data.TaggedError("MutatorNotFoundError")<{
-  readonly name: string;
-}> {}
-
-class ServerArgsParseError extends Data.TaggedError("ServerArgsParseError")<{
-  readonly cause: Cause.Cause<Schema.SchemaError>;
-}> {}
-
-const MutationUserErrorTypeId = Symbol.for(prefixId("MutationUserError"));
-class MutationUserError extends Data.TaggedError("MutationUserError")<{
-  readonly cause: Cause.Cause<unknown>;
-}> {
-  readonly [MutationUserErrorTypeId] = MutationUserErrorTypeId;
-  static is(e: unknown): e is MutationUserError {
-    return Predicate.hasProperty(e, MutationUserErrorTypeId);
-  }
-
-  override get message() {
-    const err = Cause.squash(this.cause);
-    return err instanceof Error ? err.message : "exception was not of type `Error`";
-  }
-}
+class HandleMutateError extends Data.TaggedError("HandleMutateError")<{ readonly cause: Cause.Cause<unknown> }> {}
 
 export const handleQuery = Effect.fn(function* <E, R1, R2>(
   queries: MakeQueryResult<E, R1, R2>[],

--- a/src/types.test.ts
+++ b/src/types.test.ts
@@ -165,7 +165,7 @@ describe("Type tests", () => {
         },
       });
 
-      const serverEffect = Server.processPush(serverTransaction, mutators, {} as any, {} as any);
+      const serverEffect = Server.handleMutate(serverTransaction, mutators, {} as any, {} as any);
 
       // Server effect should require both NestedDummyTag and NestedDummyTag2
       expectTypeOf<Effect.Services<typeof serverEffect>>().toEqualTypeOf<NestedDummyTag | NestedDummyTag2>();
@@ -193,13 +193,13 @@ describe("Type tests", () => {
         }),
       });
 
-      const serverEffect = Server.processPush(serverTransaction, mutators, {} as any, {} as any);
+      const serverEffect = Server.handleMutate(serverTransaction, mutators, {} as any, {} as any);
 
       // Server effect should require both DummyTag and DummyTag2
       expectTypeOf<Effect.Services<typeof serverEffect>>().toEqualTypeOf<DummyTag | DummyTag2>();
     });
 
-    it("processPush has no extra requirements when mutators have none", () => {
+    it("handleMutate has no extra requirements when mutators have none", () => {
       const clientTransaction = ClientTransaction.make("TestClientTransaction3", mockZeroSchema);
       const serverTransaction = ServerTransaction.make("TestServerTransaction2", mockDatabase, clientTransaction);
 
@@ -211,7 +211,7 @@ describe("Type tests", () => {
         simple: Effect.fn(function* () {}),
       });
 
-      const effect = Server.processPush(serverTransaction, mutators, {} as any, {} as any);
+      const effect = Server.handleMutate(serverTransaction, mutators, {} as any, {} as any);
 
       expectTypeOf<Effect.Services<typeof effect>>().toEqualTypeOf<never>();
     });

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -33,7 +33,7 @@ import * as ZfxQuery from "effect-zero/query";
 import * as ZfxResult from "effect-zero/result";
 import * as ZfxServer from "effect-zero/server";
 import * as ZfxServerTransaction from "effect-zero/server-transaction";
-import { PushBody, PushParams, PushResponse } from "effect-zero/types/push";
+import { PushBody, PushParams, type PushResponse } from "effect-zero/types/push";
 import { TransformRequestMessage } from "effect-zero/types/queries";
 import { nanoid } from "nanoid";
 import postgres from "postgres";
@@ -304,12 +304,12 @@ beforeAll(async () => {
     Effect.gen(function* () {
       const params = yield* HttpRouter.schemaParams(PushParams);
       const payload = yield* HttpServerRequest.schemaBodyJson(PushBody);
-      const result = yield* ZfxServer.processPush(serverTransaction, serverMutators, params, payload);
-      const responseBody = yield* Schema.encodeEffect(PushResponse)(result);
+      // `handleMutate` returns the upstream push response already in wire format, so no encoding step.
+      const result = yield* ZfxServer.handleMutate(serverTransaction, serverMutators, params, payload);
 
-      responses = Chunk.append(responses, responseBody);
+      responses = Chunk.append(responses, result as unknown as PushResponse);
 
-      return (yield* HttpServerResponse.json(responseBody)).pipe(
+      return (yield* HttpServerResponse.json(result)).pipe(
         HttpServerResponse.setStatus(200),
         HttpServerResponse.setHeader("content-type", "application/json"),
       );
@@ -367,8 +367,8 @@ test("server is running", async () => {
   await expect(response.text()).resolves.toEqual("OK");
 });
 
-test("processPush has no extra requirements", () => {
-  const effect = ZfxServer.processPush(serverTransaction, serverMutators, {} as any, {} as any);
+test("handleMutate has no extra requirements", () => {
+  const effect = ZfxServer.handleMutate(serverTransaction, serverMutators, {} as any, {} as any);
 
   expectTypeOf<Effect.Services<typeof effect>>().toEqualTypeOf<never>();
 });
@@ -416,7 +416,7 @@ test("mutator requirements should propagate", () => {
       yield* DummyTag2;
     }),
   });
-  const serverEffect = ZfxServer.processPush(serverTransaction, mutators, {} as any, {} as any);
+  const serverEffect = ZfxServer.handleMutate(serverTransaction, mutators, {} as any, {} as any);
 
   expectTypeOf<Effect.Services<typeof serverEffect>>().toEqualTypeOf<DummyTag | DummyTag2>();
 });
@@ -696,14 +696,16 @@ it.live(
     /*
     In case of "out of order" error, the mutation promise is not rejected, but retried under the hood.
     Since it won't ever be resolved or rejected in our case, we just run the mutation and check that
-    the last server response was "oooMutation" error.
+    the last server response was a top-level "PushFailed" error with reason "oooMutation".
+    (Upstream Zero reworked out-of-order handling into a top-level push error that stops the batch,
+    rather than a per-mutation `oooMutation` result.)
   */
     z.mutate.messages.create({ id: nanoid(), body: "hello world" }).server.then();
 
     yield* Effect.sleep(Duration.millis(100));
 
     const lastResponse = pipe(responses, Chunk.last, Option.getOrThrow);
-    expect(lastResponse).toHaveProperty(["mutations", 0, "result", "error"], "oooMutation");
+    expect(lastResponse).toMatchObject({ kind: "PushFailed", origin: "server", reason: "oooMutation" });
   }),
 );
 


### PR DESCRIPTION
Closes #34 (Push Processing Rework).

## What

Mirrors the existing `handleQuery` → `handleQueryRequest` pattern for mutations:
`handleMutate` is now a thin Effect-ful wrapper around Zero's upstream
`handleMutateRequest`, and the hand-rolled push pipeline is deleted
(`processPush`, `processMutation`, `processMutationError`, and our reimplemented
`checkAndIncrementLastMutationId`).

Zero 1.3.0's new `transact` API lets a mutator control *when* its DB transaction
opens, which is the one capability that previously forced us to reimplement the
whole pipeline. `serverTransaction.execute` now drives the upstream `transact`
(supplied per-mutation via a context service) instead of calling
`database.transaction` directly. Upstream now owns:

- the per-mutation loop and last-mutation-id ordering (out-of-order / already-processed)
- the "mutator threw inside the transaction → retry without the mutator → write app error" path
- app-error response construction (`makeAppErrorResponse`)

so this machinery no longer needs re-auditing on each Zero upgrade.

## Public API

Unchanged: `ServerTransaction.make`, `serverTransaction.execute` / `.use`,
`Mutators.make`, and mutator authoring (`...pipe(serverTransaction.execute)`).
`execute` still returns the inner effect's value so post-transaction code runs.
The `Server.processPush` export is replaced by `Server.handleMutate` (pre-1.0).

## Intended behavior change

Out-of-order mutations now surface as a **top-level `PushFailed`**
(`origin: "server", reason: "oooMutation"`) that stops the batch, instead of a
per-mutation `oooMutation` result — this matches upstream's reworked error
semantics and is already marked `@deprecated` in our `types/push` schema. The
single OOO test is updated accordingly; all app-error `details` assertions are
preserved.

## Verification

- `tsc` (src) and `bun test:types` (tests) pass — requirement propagation
  (`Effect.Services === never` / mutator-tag union) is preserved.
- `bun run test` (src unit tests): 40 passing.
- `bun run build`: export surface intact (`handleMutate` replaces `processPush`).
- The `it.live` integration suite (the 10 error-semantics cases) runs in CI
  (Postgres + zero-cache), which is the source of truth for runtime behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)