### PR TITLE
Centralize mutator-tree traversal, lookup, and arg decoding

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -4,14 +4,11 @@ import * as Data from "effect/Data";
 import * as Effect from "effect/Effect";
 import * as Exit from "effect/Exit";
 import type { NodeInspectSymbol } from "effect/Inspectable";
-import * as Match from "effect/Match";
-import * as Predicate from "effect/Predicate";
-import * as Rec from "effect/Record";
-import * as Schema from "effect/Schema";
+import type * as Schema from "effect/Schema";
 import type * as Unify from "effect/Unify";
 import type * as ClientTransaction from "./client-transaction.js";
-import { normalizeArgs } from "./internal/utils.js";
-import * as Mutators from "./mutators.js";
+import { decodeArgs, mapLeaves } from "./internal/mutator-tree.js";
+import type * as Mutators from "./mutators.js";
 
 type _NodeInspectSymbol = NodeInspectSymbol;
 type _Unify = Unify.typeSymbol | Unify.unifySymbol | Unify.ignoreSymbol;
@@ -26,9 +23,9 @@ export const make = Effect.fn(function* <TSchema extends ZeroSchema, TMutators e
       Exclude<Mutators.ExtractMutatorsRequirements<TMutators>, (typeof transaction.Context)["Identifier"]>
     >();
 
-  function unwrapMutator<E>(mutator: Mutators.AnyMutator<Mutators.ExtractMutatorsRequirements<TMutators>, E>) {
+  function unwrapMutator(mutator: Mutators.AnyMutator<Mutators.ExtractMutatorsRequirements<TMutators>>) {
     return async (tx: ZeroTransaction<TSchema>, args: unknown, _ctx: unknown) => {
-      const exit = await Schema.decodeUnknownEffect(mutator[Mutators.MutatorSchemaSymbol])(normalizeArgs(args)).pipe(
+      const exit = await decodeArgs(mutator, args).pipe(
         Effect.catchTag("SchemaError", (e) => Effect.fail(new ClientArgsParseError({ cause: Cause.fail(e) }))),
         Effect.flatMap(mutator),
         Effect.provideService(transaction.Context, tx),
@@ -42,9 +39,10 @@ export const make = Effect.fn(function* <TSchema extends ZeroSchema, TMutators e
     };
   }
 
-  const unwrappedMutators = Rec.map(mutators, (v) =>
-    Match.value(v).pipe(Match.when(Predicate.isFunction, unwrapMutator), Match.orElse(Rec.map(unwrapMutator))),
-  ) as ZeroOptions<TSchema, UnwrapMutators<TSchema, TMutators>>["mutators"];
+  const unwrappedMutators = mapLeaves(mutators, unwrapMutator) as ZeroOptions<
+    TSchema,
+    UnwrapMutators<TSchema, TMutators>
+  >["mutators"];
 
   return yield* Effect.acquireRelease(
     Effect.sync(() => {

--- a/src/internal/mutator-tree.ts
+++ b/src/internal/mutator-tree.ts
@@ -1,0 +1,39 @@
+import * as Effect from "effect/Effect";
+import * as Fn from "effect/Function";
+import * as Match from "effect/Match";
+import * as Option from "effect/Option";
+import * as Predicate from "effect/Predicate";
+import * as Rec from "effect/Record";
+import * as Schema from "effect/Schema";
+import * as Str from "effect/String";
+import { type AnyMutator, type AnyMutators, MutatorSchemaSymbol } from "../mutators.js";
+import { normalizeArgs } from "./utils.js";
+
+// The shape of a mutator tree (flat mutators and/or one level of namespaced mutators) is understood in
+// several places (client unwrapping, server lookup). These helpers own that knowledge in one spot.
+
+// Apply `f` to every leaf mutator, preserving the (flat or one-level-nested) tree shape.
+export const mapLeaves = <R, A>(mutators: AnyMutators<R>, f: (mutator: AnyMutator<R>) => A) =>
+  Rec.map(mutators, (node) => Match.value(node).pipe(Match.when(Predicate.isFunction, f), Match.orElse(Rec.map(f))));
+
+// Resolve a wire mutation name to its leaf mutator. Supports a flat "name" as well as the
+// "namespace|name" and "namespace.name" namespaced forms.
+export const lookupLeaf = <R>(mutators: AnyMutators<R>, name: string): Option.Option<AnyMutator<R>> =>
+  Fn.pipe(name.includes("|") ? Str.split(name, "|") : Str.split(name, "."), ([namespace, leaf]) =>
+    Fn.pipe(
+      mutators,
+      Rec.get<string>(namespace),
+      Option.flatMap((mutator) =>
+        Match.value([mutator, leaf]).pipe(
+          Match.when([Predicate.isObject, Predicate.isString], ([mutator, leaf]) => Rec.get<string>(leaf)(mutator)),
+          Match.when([Predicate.isFunction, Predicate.isUndefined], ([mutator]) => Option.some(mutator)),
+          Match.orElse(() => Option.none()),
+        ),
+      ),
+    ),
+  );
+
+// Normalize Zero's argument payload and decode it with the leaf's attached schema (fails with a
+// SchemaError, which callers map to their own client/server parse error).
+export const decodeArgs = (mutator: AnyMutator, raw: unknown) =>
+  Schema.decodeUnknownEffect(mutator[MutatorSchemaSymbol])(normalizeArgs(raw));

--- a/src/server.ts
+++ b/src/server.ts
@@ -5,19 +5,16 @@ import * as Cause from "effect/Cause";
 import * as Data from "effect/Data";
 import * as Effect from "effect/Effect";
 import * as Exit from "effect/Exit";
-import * as Fn from "effect/Function";
 import type { NodeInspectSymbol } from "effect/Inspectable";
-import * as Match from "effect/Match";
 import * as Option from "effect/Option";
 import * as Predicate from "effect/Predicate";
-import * as Rec from "effect/Record";
-import * as Schema from "effect/Schema";
-import * as Str from "effect/String";
+import type * as Schema from "effect/Schema";
 import * as SynchronizedRef from "effect/SynchronizedRef";
 import type * as Unify from "effect/Unify";
+import { decodeArgs, lookupLeaf } from "./internal/mutator-tree.js";
 import { MutatorNotFoundError, ServerArgsParseError, toApplicationError } from "./internal/server.js";
-import { normalizeArgs, prefixId } from "./internal/utils.js";
-import * as Mutators from "./mutators.js";
+import { prefixId } from "./internal/utils.js";
+import type * as Mutators from "./mutators.js";
 import { type MakeQueryResult, QueryNameSymbol, RunQuerySymbol } from "./query.js";
 import type * as ServerTransaction from "./server-transaction.js";
 import type * as Types from "./types/push.js";
@@ -103,26 +100,14 @@ const lookupAndDecode = Effect.fn(function* <R>(
   mutators: Mutators.AnyMutators<R>,
   mutation: { readonly name: string; readonly args: ReadonlyArray<ReadonlyJSONValue> },
 ) {
-  // Support both "namespace|name" and "namespace.name" formats, and single-segment names.
-  const [namespace, name] = mutation.name.includes("|") ? Str.split(mutation.name, "|") : Str.split(mutation.name, ".");
-
-  const mutator = yield* Fn.pipe(
-    mutators,
-    Rec.get<string>(namespace),
-    Option.flatMap((mutator) =>
-      Match.value([mutator, name]).pipe(
-        Match.when([Predicate.isObject, Predicate.isString], ([mutator, name]) => Rec.get<string>(name)(mutator)),
-        Match.when([Predicate.isFunction, Predicate.isUndefined], ([mutator]) => Option.some(mutator)),
-        Match.orElse(() => Option.none()),
-      ),
-    ),
+  const mutator = yield* lookupLeaf(mutators, mutation.name).pipe(
     Effect.fromOption,
     Effect.catchTag("NoSuchElementError", () => Effect.fail(new MutatorNotFoundError({ name: mutation.name }))),
   );
 
-  const args = yield* Schema.decodeUnknownEffect(mutator[Mutators.MutatorSchemaSymbol])(
-    normalizeArgs(mutation.args[0]),
-  ).pipe(Effect.catchTag("SchemaError", (e) => Effect.fail(new ServerArgsParseError({ cause: Cause.fail(e) }))));
+  const args = yield* decodeArgs(mutator, mutation.args[0]).pipe(
+    Effect.catchTag("SchemaError", (e) => Effect.fail(new ServerArgsParseError({ cause: Cause.fail(e) }))),
+  );
 
   return { mutator, args };
 });


### PR DESCRIPTION
Stacked on #68.

Centralizes the duplicated "mutator tree" knowledge (flat + one-level-nested mutators with a schema attached to each leaf) into one internal module, `src/internal/mutator-tree.ts`:

- `mapLeaves` — apply a function to every leaf, preserving the tree shape (used by client unwrapping)
- `lookupLeaf` — resolve a wire name (`name` / `namespace.name` / `namespace|name`) to its leaf mutator (used by the server)
- `decodeArgs` — normalize Zero's arg payload and decode it with the leaf's attached schema

`client.ts` and `server.ts` now consume these helpers instead of each re-deriving the tree shape / decode policy.

## Behavior preserved
Name-resolution semantics (incl. `|` taking precedence over `.`), the distinct `ClientArgsParseError`/`ServerArgsParseError` mapping, `null`→`undefined` normalization, and mutator **requirement propagation** (`lookupLeaf`/`mapLeaves` are generic over `R`) are all unchanged. `mutators.ts` (the tree constructor) is untouched, as are the type-level projections.

## Verification
`tsc` (src) + `bun test:types` (requirement-propagation type tests intact), `bun run test` (20 src tests), `bun run build`. Integration suite runs in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)