### PR TITLE
Simplify the query path: server lookup helper + direct result construction

### DIFF
--- a/src/internal/query-result.ts
+++ b/src/internal/query-result.ts
@@ -1,6 +1,9 @@
-import type { HumanReadable, QueryResultDetails as ZeroQueryResultDetails } from "@rocicorp/zero";
-import type { QueryResult as ZeroQueryResult } from "@rocicorp/zero/react";
-import * as Match from "effect/Match";
+import type {
+  ErroredQuery,
+  HumanReadable,
+  ResultType,
+  QueryResultDetails as ZeroQueryResultDetails,
+} from "@rocicorp/zero";
 
 // Our internal representation of Zero's QueryResult type.
 
@@ -20,11 +23,52 @@ export namespace QueryResult {
   }
 }
 
-export const make = <A>([value, details]: ZeroQueryResult<A>): QueryResult<A> => {
-  return Match.value(details).pipe(
-    Match.when({ type: "complete" }, () => ({ _tag: "Complete", value }) as const),
-    Match.when({ type: "unknown" }, () => ({ _tag: "Partial", value }) as const),
-    Match.when({ type: "error" }, ({ type: _type, ...details }) => ({ _tag: "Error", details }) as const),
-    Match.exhaustive,
-  );
+// Build the error `details` from a Zero error payload (mirrors zero-react's `makeError`, minus `type`).
+const errorDetails = (retry: () => void, error: ErroredQuery): QueryResult.Error["details"] => ({
+  retry,
+  refetch: retry,
+  error: {
+    type: error.error,
+    message: error.message ?? "An unknown error occurred",
+    ...(error.details ? { details: error.details } : {}),
+  },
+});
+
+// Build the internal `QueryResult` directly from a Zero view event, without the intermediate zero-react
+// snapshot tuple. Mirrors the composed behavior of the previous `getSnapshot` + tuple conversion.
+export const fromView = <A>(
+  singular: boolean,
+  value: HumanReadable<A>,
+  resultType: ResultType,
+  retry: () => void,
+  error?: ErroredQuery,
+): QueryResult<A> => {
+  switch (resultType) {
+    case "complete":
+      return { _tag: "Complete", value };
+    case "unknown":
+      return { _tag: "Partial", value };
+    default: {
+      if (error) return { _tag: "Error", details: errorDetails(retry, error) };
+      // No error payload: an empty result keeps empty details (as the predefined empty error snapshot
+      // did); a non-empty one falls back to a generic "app" error (as the non-empty error snapshot did).
+      const isEmpty = singular ? value === undefined : (value as ReadonlyArray<unknown>).length === 0;
+      if (isEmpty) return { _tag: "Error", details: {} as QueryResult.Error["details"] };
+      return {
+        _tag: "Error",
+        details: errorDetails(retry, {
+          error: "app",
+          id: "unknown",
+          name: "unknown",
+          message: "An unknown error occurred",
+        }),
+      };
+    }
+  }
 };
+
+// The initial (pending) result before any view event has arrived.
+export const initial = <A>(singular: boolean): QueryResult<A> => ({
+  _tag: "Partial",
+  value: (singular ? undefined : []) as unknown as HumanReadable<A>,
+});

--- a/src/query.ts
+++ b/src/query.ts
@@ -1,5 +1,7 @@
 import type { HumanReadable, ReadonlyJSONValue, Zero, Query as ZeroQuery, Schema as ZeroSchema } from "@rocicorp/zero";
 import { asQueryInternals } from "@rocicorp/zero/bindings";
+import * as Arr from "effect/Array";
+import * as Data from "effect/Data";
 import * as Effect from "effect/Effect";
 import * as Equal from "effect/Equal";
 import * as Hash from "effect/Hash";
@@ -9,7 +11,7 @@ import * as Schema from "effect/Schema";
 import * as Stream from "effect/Stream";
 import * as QueryResult from "./internal/query-result.js";
 import { prefixId } from "./internal/utils.js";
-import { deepClone, getDefaultSnapshot, getSnapshot } from "./snapshot.js";
+import { deepClone } from "./snapshot.js";
 
 // biome-ignore lint/suspicious/noConfusingVoidType: necessary to allow Schema.Void
 type QueryArgs<A extends ReadonlyJSONValue | void, B> = { _tag: "Encoded"; args: A } | { _tag: "Decoded"; args: B };
@@ -78,6 +80,25 @@ export type MakeQueryResult<E = any, R1 = any, R2 = any> = ReturnType<
   typeof make<string, any, any, string, ZeroSchema, Record<string, any> | undefined, E, R1, R2>
 >;
 
+export class QueryNotFound extends Data.TaggedError("QueryNotFound")<{ name: string }> {
+  override get message() {
+    return `Query not found: ${this.name}`;
+  }
+}
+
+// Find a query by its name and run it from its encoded (wire) arguments. Owns the query-tree lookup
+// protocol (the name/run symbols) so the server handler doesn't have to know about it.
+export const runEncodedByName = <E, R1, R2>(
+  queries: MakeQueryResult<E, R1, R2>[],
+  name: string,
+  args: ReadonlyJSONValue | undefined,
+) =>
+  Arr.findFirst(queries, (query) => query[QueryNameSymbol] === name).pipe(
+    Effect.fromOption,
+    Effect.catchTag("NoSuchElementError", () => Effect.fail(new QueryNotFound({ name }))),
+    Effect.flatMap((query) => query[RunQuerySymbol]({ _tag: "Encoded", args })),
+  );
+
 export const stream = <T extends keyof S["tables"] & string, S extends ZeroSchema, R>(
   zero: Zero<S>,
   query: ZeroQuery<T, S, R>,
@@ -95,7 +116,7 @@ export const stream = <T extends keyof S["tables"] & string, S extends ZeroSchem
         Effect.sync(() => {
           // logic here borrowed from: https://github.com/rocicorp/mono/blob/8e0f600fb3a9185facf60cfd4971d260b266690e/packages/zero-react/src/use-query.tsx#L543
           const cloned = data === undefined ? data : (deepClone(data as ReadonlyJSONValue) as HumanReadable<R>);
-          return getSnapshot<R>(
+          return QueryResult.fromView<R>(
             asQueryInternals(query).format.singular,
             cloned,
             resultType,
@@ -107,10 +128,9 @@ export const stream = <T extends keyof S["tables"] & string, S extends ZeroSchem
           );
         }),
       ),
-      Stream.map(QueryResult.make),
     );
   }).pipe(Stream.unwrap);
 
 export const initialValue = <T extends keyof S["tables"] & string, S extends ZeroSchema, R>(
   query: ZeroQuery<T, S, R>,
-) => QueryResult.make<R>(getDefaultSnapshot(asQueryInternals(query).format.singular));
+) => QueryResult.initial<R>(asQueryInternals(query).format.singular);

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,6 +1,5 @@
 import type { ReadonlyJSONValue, Schema as ZeroSchema } from "@rocicorp/zero";
 import { handleMutateRequest, handleQueryRequest, OutOfOrderMutation } from "@rocicorp/zero/server";
-import * as Arr from "effect/Array";
 import * as Cause from "effect/Cause";
 import * as Data from "effect/Data";
 import * as Effect from "effect/Effect";
@@ -18,7 +17,7 @@ import type * as Unify from "effect/Unify";
 import { MutatorNotFoundError, ServerArgsParseError, toApplicationError } from "./internal/server.js";
 import { normalizeArgs, prefixId } from "./internal/utils.js";
 import * as Mutators from "./mutators.js";
-import { type MakeQueryResult, QueryNameSymbol, RunQuerySymbol } from "./query.js";
+import { type MakeQueryResult, type QueryNotFound, runEncodedByName } from "./query.js";
 import type * as ServerTransaction from "./server-transaction.js";
 import type * as Types from "./types/push.js";
 import type { TransformRequestMessage } from "./types/queries.js";
@@ -139,18 +138,12 @@ export const handleQuery = Effect.fn(function* <E, R1, R2>(
     try: () =>
       handleQueryRequest(
         (name, args) =>
-          Arr.findFirst(queries, (q) => q[QueryNameSymbol] === name).pipe(
-            Effect.fromOption,
-            Effect.catchTag("NoSuchElementError", () => Effect.fail(new QueryNotFound({ name }))),
-            Effect.flatMap((query) => query[RunQuerySymbol]({ _tag: "Encoded", args })),
-            Effect.runSyncExitWith(ctx),
-            (exit) => {
-              if (Exit.isFailure(exit)) {
-                throw new QueryUserError<E>({ cause: exit.cause });
-              }
-              return exit.value;
-            },
-          ),
+          runEncodedByName(queries, name, args).pipe(Effect.runSyncExitWith(ctx), (exit) => {
+            if (Exit.isFailure(exit)) {
+              throw new QueryUserError<E>({ cause: exit.cause });
+            }
+            return exit.value;
+          }),
         schema,
         payload as ReadonlyJSONValue,
       ),
@@ -161,12 +154,6 @@ export const handleQuery = Effect.fn(function* <E, R1, R2>(
       ),
   });
 });
-
-class QueryNotFound extends Data.TaggedError("QueryNotFound")<{ name: string }> {
-  override get message() {
-    return `Query not found: ${this.name}`;
-  }
-}
 
 const QueryUserErrorTypeId = Symbol.for(prefixId("QueryUserError"));
 class QueryUserError<E> extends Data.TaggedError("QueryUserError")<{


### PR DESCRIPTION
Stacked on #68 (sibling of #69 — both branch from #68, not from each other).

Two related query-side structural simplifications:

### #5 — move query lookup into `query.ts`
Adds `query.ts`-owned `runEncodedByName(queries, name, args)` (and relocates `QueryNotFound` there). `handleQuery` calls it instead of importing query's internal name/run symbols and building the `{ _tag: "Encoded" }` dispatch shape itself — so the server no longer needs to know query's internal metadata protocol.

### #6 — collapse the snapshot→QueryResult double hop
`query.stream` / `initialValue` previously converted a Zero view event into a zero-react **snapshot tuple** (`getSnapshot`) and then immediately reconverted that tuple into the internal `QueryResult` ADT. They now build the ADT directly via `QueryResult.fromView` / `QueryResult.initial`. `fromView` mirrors the exact composed behavior of `getSnapshot` + the old tuple conversion (empty singular/plural handling; error with/without payload fallbacks). The snapshot tuple's React-identity optimization was already discarded by wrapping in a fresh ADT, so emitted values are unchanged.

`snapshot.ts` remains a public module (`getSnapshot`/`getDefaultSnapshot` still exported); `deepClone` is still used by the stream.

## Behavior preserved
Query-not-found and decode-error mapping, error `details` shape, empty/plural value handling, and requirement propagation are all unchanged.

## Verification
`tsc` (src) + `bun test:types`, `bun run test` (20 src tests), `bun run build`. Integration suite (incl. the synced-query tests) runs in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)