### PR TITLE
chore(release): 0.6.0-beta.0 — DO NOT MERGE (beta publish to npm `next`)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -45,4 +45,4 @@ jobs:
           bun run test
       - name: Publish
         shell: bash
-        run: npm publish package.tgz --provenance --access public
+        run: npm publish package.tgz --provenance --access public --tag next

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "effect-zero",
   "type": "module",
-  "version": "0.5.0",
+  "version": "0.6.0-beta.0",
   "license": "MIT",
   "repository": {
     "url": "https://github.com/realms-labs/effect-zero"


### PR DESCRIPTION
🚧 **Throwaway release PR — do not merge.** Close it after publishing.

Publishes the current `main` (zero 1.7-canary support + object-param handlers, unreleased since `0.5.0`) as a prerelease to the npm **`next`** tag, leaving stable `latest` = `0.5.0` untouched.

Changes (temporary, discarded on close):
- `package.json`: `0.5.0` → `0.6.0-beta.0`
- `.github/workflows/publish.yml`: add `--tag next` to the publish step so the prerelease lands on `next` (the workflow otherwise defaults to `latest`)

Release steps:
1. Let the **Tests** workflow go green here (build + Docker integration).
2. Dispatch the **Publish** workflow on this branch (`gh workflow run Publish --ref release/0.6.0-beta.0`) — it runs the full suite and `npm publish … --tag next`.
3. Verify `npm view effect-zero dist-tags` → `next` = `0.6.0-beta.0`.
4. **Close this PR without merging** and delete the branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)