### PR TITLE
chore(release): 0.6.0-beta.1 — DO NOT MERGE (beta publish to npm `next`)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -45,4 +45,4 @@ jobs:
           bun run test
       - name: Publish
         shell: bash
-        run: npm publish package.tgz --provenance --access public
+        run: npm publish package.tgz --provenance --access public --tag next

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "effect-zero",
   "type": "module",
-  "version": "0.5.0",
+  "version": "0.6.0-beta.1",
   "license": "MIT",
   "repository": {
     "url": "https://github.com/realms-labs/effect-zero"


### PR DESCRIPTION
🚧 **Throwaway release PR — do not merge.** Close after publishing.

Re-cut of the 0.6.0 beta, now built against **stable `@rocicorp/zero@1.7.0`** (branched off `main` after the stable pin bump in #75). `0.6.0-beta.0` was built against `1.7.0-canary.4`; this supersedes it on the `next` tag. `latest` stays `0.5.0`.

Temporary changes (discarded on close):
- `package.json`: `0.5.0` → `0.6.0-beta.1`
- `publish.yml`: add `--tag next`

Steps:
1. Let **Tests** go green (build + Docker integration).
2. Dispatch **Publish** on this branch → `npm publish … --tag next`.
3. Verify `npm view effect-zero dist-tags` → `next` = `0.6.0-beta.1`.
4. Close without merging + delete branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)