### PR TITLE
bump 0.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "effect-zero",
   "type": "module",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "license": "MIT",
   "repository": {
     "url": "https://github.com/realms-labs/effect-zero"


### PR DESCRIPTION
Stable **0.6.0** release — version-only bump (`package.json` `0.5.0` → `0.6.0`).

Promotes the work merged since 0.5.0 to the stable line:
- handleMutate/transact server-push migration (#71)
- `@rocicorp/zero` 1.7 upgrade — object-param handlers, per-module wire types (#73)
- stable `1.7.0` pin (#75)

Already exercised as `0.6.0-beta.0`/`0.6.0-beta.1` on the npm `next` tag. Once merged, dispatch the **Publish** workflow on `main` (no `--tag`) to publish `0.6.0` to `latest`. `next` is left at `0.6.0-beta.1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)